### PR TITLE
Hopefully fix 0.5 builds by swapping out deprecated things

### DIFF
--- a/src/SpecialFunctions.jl
+++ b/src/SpecialFunctions.jl
@@ -1,12 +1,12 @@
 module SpecialFunctions
 
-export  
+export
     airy,
     airyai,
     airyaiprime,
     airybi,
     airybiprime,
-    airyprime,    
+    airyprime,
     airyx,
     besselh,
     besseli,
@@ -37,9 +37,9 @@ const complex64 = Complex64
 const complex128 = Complex128
 
 for jy in ("j","y"), nu in (0,1)
-    jynu = Expr(:quote, symbol(string(jy,nu)))
-    jynuf = Expr(:quote, symbol(string(jy,nu,"f")))
-    bjynu = symbol(string("bessel",jy,nu))
+    jynu = Expr(:quote, Symbol(string(jy,nu)))
+    jynuf = Expr(:quote, Symbol(string(jy,nu,"f")))
+    bjynu = Symbol(string("bessel",jy,nu))
     if jy == "y"
         @eval begin
             $bjynu(x::Float64) = nan_dom_err(ccall(($jynu,libm),  Float64, (Float64,), x), x)
@@ -53,12 +53,12 @@ for jy in ("j","y"), nu in (0,1)
     end
     @eval begin
         $bjynu(x::Real) = $bjynu(float(x))
-        $bjynu(x::Complex) = $(symbol(string("bessel",jy)))($nu,x)
+        $bjynu(x::Complex) = $(Symbol(string("bessel",jy)))($nu,x)
         @vectorize_1arg Number $bjynu
     end
 end
 
-        
+
 type AmosException <: Exception
     info::Int32
 end
@@ -106,7 +106,7 @@ airybi(z) = airy(2,z)
 airybiprime(z) = airy(3,z)
 @vectorize_1arg Number airybiprime
 
-airy(k::Number, x::FloatingPoint) = oftype(x, real(airy(k, complex(x))))
+airy(k::Number, x::AbstractFloat) = oftype(x, real(airy(k, complex(x))))
 airy(k::Number, x::Real) = airy(k, float(x))
 airy(k::Number, z::Complex64) = complex64(airy(k, complex128(z)))
 airy(k::Number, z::Complex) = airy(convert(Int,k), complex128(z))
@@ -126,7 +126,7 @@ end
 airyx(z) = airyx(0,z)
 @vectorize_1arg Number airyx
 
-airyx(k::Number, x::FloatingPoint) = oftype(x, real(airyx(k, complex(x))))
+airyx(k::Number, x::AbstractFloat) = oftype(x, real(airyx(k, complex(x))))
 airyx(k::Number, x::Real) = airyx(k, float(x))
 airyx(k::Number, z::Complex64) = complex64(airyx(k, complex128(z)))
 airyx(k::Number, z::Complex) = airyx(convert(Int,k), complex128(z))
@@ -228,7 +228,7 @@ function besselj(nu::Float64, z::Complex128)
     end
 end
 
-besselj(nu::Integer, x::FloatingPoint) = typemin(Int32) <= nu <= typemax(Int32) ?
+besselj(nu::Integer, x::AbstractFloat) = typemin(Int32) <= nu <= typemax(Int32) ?
     oftype(x, ccall((:jn, libm), Float64, (Cint, Float64), nu, x)) :
     besselj(float64(nu), x)
 
@@ -258,7 +258,7 @@ end
 
 function besselyx(nu::Float64, z::Complex128)
     if nu < 0
-        return _bessely(-nu,z,int32(2))*cospi(nu) - _besselj(-nu,z,int32(2))*sinpi(nu) 
+        return _bessely(-nu,z,int32(2))*cospi(nu) - _besselj(-nu,z,int32(2))*sinpi(nu)
     else
         return _bessely(nu,z,int32(2))
     end
@@ -286,21 +286,21 @@ hankelh1x(nu, z) = besselhx(nu, 1, z)
 hankelh2x(nu, z) = besselhx(nu, 2, z)
 @vectorize_2arg Number hankelh2x
 
-function besseli(nu::Real, x::FloatingPoint)
+function besseli(nu::Real, x::AbstractFloat)
     if x < 0 && !isinteger(nu)
         throw(DomainError())
     end
     oftype(x, real(besseli(float64(nu), complex128(x))))
 end
 
-function besselix(nu::Real, x::FloatingPoint)
+function besselix(nu::Real, x::AbstractFloat)
     if x < 0 && !isinteger(nu)
         throw(DomainError())
     end
     oftype(x, real(besselix(float64(nu), complex128(x))))
 end
 
-function besselj(nu::FloatingPoint, x::FloatingPoint)
+function besselj(nu::AbstractFloat, x::AbstractFloat)
     if isinteger(nu)
         if typemin(Int32) <= nu <= typemax(Int32)
             return besselj(int(nu), x)
@@ -311,14 +311,14 @@ function besselj(nu::FloatingPoint, x::FloatingPoint)
     oftype(x, real(besselj(float64(nu), complex128(x))))
 end
 
-function besseljx(nu::Real, x::FloatingPoint)
+function besseljx(nu::Real, x::AbstractFloat)
     if x < 0 && !isinteger(nu)
         throw(DomainError())
     end
     oftype(x, real(besseljx(float64(nu), complex128(x))))
 end
 
-function besselk(nu::Real, x::FloatingPoint)
+function besselk(nu::Real, x::AbstractFloat)
     if x < 0
         throw(DomainError())
     end
@@ -328,7 +328,7 @@ function besselk(nu::Real, x::FloatingPoint)
     oftype(x, real(besselk(float64(nu), complex128(x))))
 end
 
-function besselkx(nu::Real, x::FloatingPoint)
+function besselkx(nu::Real, x::AbstractFloat)
     if x < 0
         throw(DomainError())
     end
@@ -338,7 +338,7 @@ function besselkx(nu::Real, x::FloatingPoint)
     oftype(x, real(besselkx(float64(nu), complex128(x))))
 end
 
-function bessely(nu::Real, x::FloatingPoint)
+function bessely(nu::Real, x::AbstractFloat)
     if x < 0
         throw(DomainError())
     end
@@ -347,7 +347,7 @@ function bessely(nu::Real, x::FloatingPoint)
     end
     oftype(x, real(bessely(float64(nu), complex128(x))))
 end
-function bessely(nu::Integer, x::FloatingPoint)
+function bessely(nu::Integer, x::AbstractFloat)
     if x < 0
         throw(DomainError())
     end
@@ -360,7 +360,7 @@ function bessely(nu::Integer, x::Float32)
     return ccall((:ynf, libm), Float32, (Cint, Float32), nu, x)
 end
 
-function besselyx(nu::Real, x::FloatingPoint)
+function besselyx(nu::Real, x::AbstractFloat)
     if x < 0
         throw(DomainError())
     end
@@ -368,7 +368,7 @@ function besselyx(nu::Real, x::FloatingPoint)
 end
 
 for f in ("i", "ix", "j", "jx", "k", "kx", "y", "yx")
-    bfn = symbol(string("bessel", f))
+    bfn = Symbol(string("bessel", f))
     @eval begin
         $bfn(nu::Real, z::Complex64) = complex64($bfn(float64(nu), complex128(z)))
         $bfn(nu::Real, z::Complex) = $bfn(float64(nu), complex128(z))

--- a/test/bessel.jl
+++ b/test/bessel.jl
@@ -1,82 +1,82 @@
 # airy
-@test_approx_eq airy(1.8) 0.0470362168668458052247
-@test_approx_eq airyprime(1.8) -0.0685247801186109345638
-@test_approx_eq airybi(1.8) 2.595869356743906290060
-@test_approx_eq airybiprime(1.8) 2.98554005084659907283
-@test_throws SpecialFunctions.AmosException airy(200im)
-@test_throws SpecialFunctions.AmosException airybi(200)
+@test_approx_eq SpecialFunctions.airy(1.8) 0.0470362168668458052247
+@test_approx_eq SpecialFunctions.airyprime(1.8) -0.0685247801186109345638
+@test_approx_eq SpecialFunctions.airybi(1.8) 2.595869356743906290060
+@test_approx_eq SpecialFunctions.airybiprime(1.8) 2.98554005084659907283
+@test_throws SpecialFunctions.AmosException SpecialFunctions.airy(200im)
+@test_throws SpecialFunctions.AmosException SpecialFunctions.airybi(200)
 z = 1.8 + 1.0im
-@test_approx_eq airyx(0, z) airy(0, z) * exp(2/3 * z * sqrt(z))
-@test_approx_eq airyx(1, z) airy(1, z) * exp(2/3 * z * sqrt(z))
-@test_approx_eq airyx(2, z) airy(2, z) * exp(-abs(real(2/3 * z * sqrt(z))))
-@test_approx_eq airyx(3, z) airy(3, z) * exp(-abs(real(2/3 * z * sqrt(z))))
+@test_approx_eq SpecialFunctions.airyx(0, z) SpecialFunctions.airy(0, z) * exp(2/3 * z * sqrt(z))
+@test_approx_eq SpecialFunctions.airyx(1, z) SpecialFunctions.airy(1, z) * exp(2/3 * z * sqrt(z))
+@test_approx_eq SpecialFunctions.airyx(2, z) SpecialFunctions.airy(2, z) * exp(-abs(real(2/3 * z * sqrt(z))))
+@test_approx_eq SpecialFunctions.airyx(3, z) SpecialFunctions.airy(3, z) * exp(-abs(real(2/3 * z * sqrt(z))))
 
 # besselh
 true_h133 = 0.30906272225525164362 - 0.53854161610503161800im
-@test_approx_eq besselh(3,1,3) true_h133
-@test_approx_eq besselh(-3,1,3) -true_h133
-@test_approx_eq besselh(3,2,3) conj(true_h133)
-@test_approx_eq besselh(-3,2,3) -conj(true_h133)
-@test_throws SpecialFunctions.AmosException besselh(1,0)
+@test_approx_eq SpecialFunctions.besselh(3,1,3) true_h133
+@test_approx_eq SpecialFunctions.besselh(-3,1,3) -true_h133
+@test_approx_eq SpecialFunctions.besselh(3,2,3) conj(true_h133)
+@test_approx_eq SpecialFunctions.besselh(-3,2,3) -conj(true_h133)
+@test_throws SpecialFunctions.AmosException SpecialFunctions.besselh(1,0)
 
 # besseli
 true_i33 = 0.95975362949600785698
-@test_approx_eq besseli(3,3) true_i33
-@test_approx_eq besseli(-3,3) true_i33
-@test_approx_eq besseli(3,-3) -true_i33
-@test_approx_eq besseli(-3,-3) -true_i33
-@test_throws SpecialFunctions.AmosException besseli(1,1000)
+@test_approx_eq SpecialFunctions.besseli(3,3) true_i33
+@test_approx_eq SpecialFunctions.besseli(-3,3) true_i33
+@test_approx_eq SpecialFunctions.besseli(3,-3) -true_i33
+@test_approx_eq SpecialFunctions.besseli(-3,-3) -true_i33
+@test_throws SpecialFunctions.AmosException SpecialFunctions.besseli(1,1000)
 
 # besselj
-@test besselj(0,0) == 1
+@test SpecialFunctions.besselj(0,0) == 1
 for i = 1:5
-    @test besselj(i,0) == 0
-    @test besselj(-i,0) == 0
+    @test SpecialFunctions.besselj(i,0) == 0
+    @test SpecialFunctions.besselj(-i,0) == 0
 end
 
-j33 = besselj(3,3.)
-@test besselj(3,3) == j33
-@test besselj(-3,-3) == j33
-@test besselj(-3,3) == -j33
-@test besselj(3,-3) == -j33
+j33 = SpecialFunctions.besselj(3,3.)
+@test SpecialFunctions.besselj(3,3) == j33
+@test SpecialFunctions.besselj(-3,-3) == j33
+@test SpecialFunctions.besselj(-3,3) == -j33
+@test SpecialFunctions.besselj(3,-3) == -j33
 
-j43 = besselj(4,3.)
-@test besselj(4,3) == j43
-@test besselj(-4,-3) == j43
-@test besselj(-4,3) == j43
-@test besselj(4,-3) == j43
+j43 = SpecialFunctions.besselj(4,3.)
+@test SpecialFunctions.besselj(4,3) == j43
+@test SpecialFunctions.besselj(-4,-3) == j43
+@test SpecialFunctions.besselj(-4,3) == j43
+@test SpecialFunctions.besselj(4,-3) == j43
 
 @test_approx_eq j33 0.30906272225525164362
 @test_approx_eq j43 0.13203418392461221033
-@test_throws DomainError    besselj(0.1, -0.4)
-@test_approx_eq besselj(0.1, complex(-0.4)) 0.820421842809028916 + 0.266571215948350899im
-@test_approx_eq besselj(3.2, 1.3+0.6im) 0.01135309305831220201 + 0.03927719044393515275im
-@test_approx_eq besselj(1, 3im) 3.953370217402609396im
-@test_throws SpecialFunctions.AmosException besselj(20,1000im)
+@test_throws DomainError    SpecialFunctions.besselj(0.1, -0.4)
+@test_approx_eq SpecialFunctions.besselj(0.1, complex(-0.4)) 0.820421842809028916 + 0.266571215948350899im
+@test_approx_eq SpecialFunctions.besselj(3.2, 1.3+0.6im) 0.01135309305831220201 + 0.03927719044393515275im
+@test_approx_eq SpecialFunctions.besselj(1, 3im) 3.953370217402609396im
+@test_throws SpecialFunctions.AmosException SpecialFunctions.besselj(20,1000im)
 
 # besselk
 true_k33 = 0.12217037575718356792
-@test_approx_eq besselk(3,3) true_k33
-@test_approx_eq besselk(-3,3) true_k33
+@test_approx_eq SpecialFunctions.besselk(3,3) true_k33
+@test_approx_eq SpecialFunctions.besselk(-3,3) true_k33
 true_k3m3 = -0.1221703757571835679 - 3.0151549516807985776im
-@test_throws DomainError besselk(3,-3)
-@test_approx_eq besselk(3,complex(-3)) true_k3m3
-@test_approx_eq besselk(-3,complex(-3)) true_k3m3
-@test_throws SpecialFunctions.AmosException besselk(200,0.01)
+@test_throws DomainError SpecialFunctions.besselk(3,-3)
+@test_approx_eq SpecialFunctions.besselk(3,complex(-3)) true_k3m3
+@test_approx_eq SpecialFunctions.besselk(-3,complex(-3)) true_k3m3
+@test_throws SpecialFunctions.AmosException SpecialFunctions.besselk(200,0.01)
 # issue #6564
-@test besselk(1.0,0.0) == Inf
+@test SpecialFunctions.besselk(1.0,0.0) == Inf
 
 # bessely
-y33 = bessely(3,3.)
-@test bessely(3,3) == y33
-@test_approx_eq bessely(-3,3) -y33
+y33 = SpecialFunctions.bessely(3,3.)
+@test SpecialFunctions.bessely(3,3) == y33
+@test_approx_eq SpecialFunctions.bessely(-3,3) -y33
 @test_approx_eq y33 -0.53854161610503161800
-@test_throws DomainError bessely(3,-3)
-@test_approx_eq bessely(3,complex(-3)) 0.53854161610503161800 - 0.61812544451050328724im
-@test_throws SpecialFunctions.AmosException bessely(200.5,0.1)
+@test_throws DomainError SpecialFunctions.bessely(3,-3)
+@test_approx_eq SpecialFunctions.bessely(3,complex(-3)) 0.53854161610503161800 - 0.61812544451050328724im
+@test_throws SpecialFunctions.AmosException SpecialFunctions.bessely(200.5,0.1)
 
 # issue #6653
-for f in (besselj,bessely,besseli,besselk,hankelh1,hankelh2)
+for f in (SpecialFunctions.besselj,SpecialFunctions.bessely,SpecialFunctions.besseli,SpecialFunctions.besselk,SpecialFunctions.hankelh1,SpecialFunctions.hankelh2)
     @test_approx_eq f(0,1) f(0,Complex128(1))
     @test_approx_eq f(0,1) f(0,Complex64(1))
 end
@@ -84,19 +84,19 @@ end
 # scaled bessel[ijky] and hankelh[12]
 for x in (1.0, 0.0, -1.0), y in (1.0, 0.0, -1.0), nu in (1.0, 0.0, -1.0)
     z = Complex128(x + y * im)
-    z == zero(z) || @test_approx_eq hankelh1x(nu, z) hankelh1(nu, z) * exp(-z * im)
-    z == zero(z) || @test_approx_eq hankelh2x(nu, z) hankelh2(nu, z) * exp(z * im)
-    (nu < 0 && z == zero(z)) || @test_approx_eq besselix(nu, z) besseli(nu, z) * exp(-abs(real(z)))
-    (nu < 0 && z == zero(z)) || @test_approx_eq besseljx(nu, z) besselj(nu, z) * exp(-abs(imag(z)))
-    z == zero(z) || @test_approx_eq besselkx(nu, z) besselk(nu, z) * exp(z)
-    z == zero(z) || @test_approx_eq besselyx(nu, z) bessely(nu, z) * exp(-abs(imag(z)))
+    z == zero(z) || @test_approx_eq SpecialFunctions.hankelh1x(nu, z) SpecialFunctions.hankelh1(nu, z) * exp(-z * im)
+    z == zero(z) || @test_approx_eq SpecialFunctions.hankelh2x(nu, z) SpecialFunctions.hankelh2(nu, z) * exp(z * im)
+    (nu < 0 && z == zero(z)) || @test_approx_eq SpecialFunctions.besselix(nu, z) SpecialFunctions.besseli(nu, z) * exp(-abs(real(z)))
+    (nu < 0 && z == zero(z)) || @test_approx_eq SpecialFunctions.besseljx(nu, z) SpecialFunctions.besselj(nu, z) * exp(-abs(imag(z)))
+    z == zero(z) || @test_approx_eq SpecialFunctions.besselkx(nu, z) SpecialFunctions.besselk(nu, z) * exp(z)
+    z == zero(z) || @test_approx_eq SpecialFunctions.besselyx(nu, z) SpecialFunctions.bessely(nu, z) * exp(-abs(imag(z)))
 end
-@test_throws SpecialFunctions.AmosException hankelh1x(1, 0)
-@test_throws SpecialFunctions.AmosException hankelh2x(1, 0)
-@test_throws SpecialFunctions.AmosException besselix(-1, 0)
-@test_throws SpecialFunctions.AmosException besseljx(-1, 0)
-@test besselkx(1, 0) == Inf
-@test_throws SpecialFunctions.AmosException besselyx(1, 0)
+@test_throws SpecialFunctions.AmosException SpecialFunctions.hankelh1x(1, 0)
+@test_throws SpecialFunctions.AmosException SpecialFunctions.hankelh2x(1, 0)
+@test_throws SpecialFunctions.AmosException SpecialFunctions.besselix(-1, 0)
+@test_throws SpecialFunctions.AmosException SpecialFunctions.besseljx(-1, 0)
+@test SpecialFunctions.besselkx(1, 0) == Inf
+@test_throws SpecialFunctions.AmosException SpecialFunctions.besselyx(1, 0)
 
 # values from Abramowitz & Stegun, Table 10.11 (p475)
 #   x     Ai(x)         Ai'(x)       Bi(x)        Bi'(x)       x     Ai(x)         Ai'(x)       Bi(x)        Bi'(x)
@@ -161,17 +161,17 @@ for i = 1:size(table10p11,1)
     aip = table10p11[i,3]
     bi  = table10p11[i,4]
     bip = table10p11[i,5]
-    @test_approx_eq_eps ai airyai(x) tol
-    @test_approx_eq_eps aip airyaiprime(x) tol
-    @test_approx_eq_eps bi airybi(x) tol
-    @test_approx_eq_eps bip airybiprime(x) tol
+    @test_approx_eq_eps ai SpecialFunctions.airyai(x) tol
+    @test_approx_eq_eps aip SpecialFunctions.airyaiprime(x) tol
+    @test_approx_eq_eps bi SpecialFunctions.airybi(x) tol
+    @test_approx_eq_eps bip SpecialFunctions.airybiprime(x) tol
     x   = table10p11[i,6]
     ai  = table10p11[i,7]
     aip = table10p11[i,8]
     bi  = table10p11[i,9]
     bip = table10p11[i,10]
-    @test_approx_eq_eps ai airyai(x) tol
-    @test_approx_eq_eps aip airyaiprime(x) tol
-    @test_approx_eq_eps bi airybi(x) tol
-    @test_approx_eq_eps bip airybiprime(x) tol
+    @test_approx_eq_eps ai SpecialFunctions.airyai(x) tol
+    @test_approx_eq_eps aip SpecialFunctions.airyaiprime(x) tol
+    @test_approx_eq_eps bi SpecialFunctions.airybi(x) tol
+    @test_approx_eq_eps bip SpecialFunctions.airybiprime(x) tol
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,10 +2,10 @@ using SpecialFunctions
 using Base.Test
 
 # override Main
-for f in names(SpecialFunctions)
-    if isdefined(Main,f)
-        @eval global const $f = SpecialFunctions.$f
-    end
-end
+# for f in names(SpecialFunctions)
+#     if isdefined(Main,f)
+#         @eval global const $f = SpecialFunctions.$f
+#     end
+# end
 
 include("bessel.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
-include("../src/SpecialFunctions.jl")
-import SpecialFunctions
+using SpecialFunctions
 using Base.Test
 
 # override Main


### PR DESCRIPTION
`FloatingPoint` is deprecated in 0.4 and has since been removed, which is causing the failures on the nightlies. I swapped that out for `AbstractFloat`. I similarly swapped `symbol` for `Symbol` to remove the deprecation warnings. The format of runtests.jl was kind of weird so I updated it to use the more standard (AFAIK) format. While I was at it, I also removed trailing whitespace. Now let's see what happens...