### PR TITLE
Cope with life after Base removal of special functions

### DIFF
--- a/src/SpecialFunctions.jl
+++ b/src/SpecialFunctions.jl
@@ -2,58 +2,64 @@ __precompile__()
 
 module SpecialFunctions
 
-# On older versions these are exported from Base
-# TODO: Uncomment me once these have been removed!
-#if VERSION >= v"0.6.0-dev.XXXX"
-#    export
-#        airyai,
-#        airyaiprime,
-#        airybi,
-#        airybiprime,
-#        airyaix,
-#        airyaiprimex,
-#        airybix,
-#        airybiprimex,
-#        besselh,
-#        besselhx,
-#        besseli,
-#        besselix,
-#        besselj,
-#        besselj0,
-#        besselj1,
-#        besseljx,
-#        besselk,
-#        besselkx,
-#        bessely,
-#        bessely0,
-#        bessely1,
-#        besselyx,
-#        dawson,
-#        erf,
-#        erfc,
-#        erfcinv,
-#        erfcx,
-#        erfi,
-#        erfinv,
-#        eta,
-#        digamma,
-#        invdigamma,
-#        polygamma,
-#        trigamma,
-#        hankelh1,
-#        hankelh1x,
-#        hankelh2,
-#        hankelh2x,
-#        zeta
-#end
+if VERSION >= v"0.6.0-dev.2767"
+    if isdefined(Base, :airyai)
+        import Base: airyai, airyaix, airyaiprime, airyaiprimex,
+                     airybi, airybix, airybiprime, airybiprimex,
+                     besselh, besselhx, besseli, besselix, besselj, besselj0, besselj1,
+                     besseljx, besselk, besselkx, bessely, bessely0, bessely1, besselyx,
+                     hankelh1, hankelh1x, hankelh2, hankelh2x,
+                     dawson, erf, erfc, erfcinv, erfcx, erfi, erfinv,
+                     eta, digamma, invdigamma, polygamma, trigamma, zeta
+    else
+        export
+            airyai,
+            airyaiprime,
+            airybi,
+            airybiprime,
+            airyaix,
+            airyaiprimex,
+            airybix,
+            airybiprimex,
+            besselh,
+            besselhx,
+            besseli,
+            besselix,
+            besselj,
+            besselj0,
+            besselj1,
+            besseljx,
+            besselk,
+            besselkx,
+            bessely,
+            bessely0,
+            bessely1,
+            besselyx,
+            dawson,
+            erf,
+            erfc,
+            erfcinv,
+            erfcx,
+            erfi,
+            erfinv,
+            eta,
+            digamma,
+            invdigamma,
+            polygamma,
+            trigamma,
+            hankelh1,
+            hankelh1x,
+            hankelh2,
+            hankelh2x,
+            zeta
+    end
+end
 
-# On older versions libopenspecfun is included in Base
-# TODO: Uncomment me once Base no longer ships with it!
-#if VERSION >= v"0.6.0-dev.XXXX"
-#    const openspecfun = "libopenspecfun"
-#else
+if isdefined(Base.Math, :openspecfun)
     const openspecfun = Base.Math.openspecfun
-#end
+else
+    const openspecfun = "libopenspecfun"
+end
 
 include("bessel.jl")
 include("erf.jl")


### PR DESCRIPTION
This plugs in the version number corresponding to the commit that deprecates the functions in Base. Now with 200% more importing and exporting!