### PR TITLE
Also import deprecated functions from Base

### DIFF
--- a/src/SpecialFunctions.jl
+++ b/src/SpecialFunctions.jl
@@ -10,7 +10,9 @@ if VERSION >= v"0.6.0-dev.2767"
                      besseljx, besselk, besselkx, bessely, bessely0, bessely1, besselyx,
                      hankelh1, hankelh1x, hankelh2, hankelh2x,
                      dawson, erf, erfc, erfcinv, erfcx, erfi, erfinv,
-                     eta, digamma, invdigamma, polygamma, trigamma, zeta
+                     eta, digamma, invdigamma, polygamma, trigamma, zeta,
+                     # deprecated
+                     airy, airyx, airyprime
     else
         export
             airyai,


### PR DESCRIPTION
@tkelman Is this what you had in mind, or should these have a separate `isdefined` check?