### PR TITLE
Bump Julia to 0.6, fix 0.7 depwarns, remove some deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Most of these functions were formerly part of Base.
 [![Coverage Status](https://coveralls.io/repos/github/JuliaMath/SpecialFunctions.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaMath/SpecialFunctions.jl?branch=master)
 
 Latest release:
-[![SpecialFunctions](http://pkg.julialang.org/badges/SpecialFunctions_0.5.svg)](http://pkg.julialang.org/?pkg=SpecialFunctions)
 [![SpecialFunctions](http://pkg.julialang.org/badges/SpecialFunctions_0.6.svg)](http://pkg.julialang.org/?pkg=SpecialFunctions)
 
 Documentation:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.5
-Compat 0.18.0
+julia 0.6

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/SpecialFunctions.jl
+++ b/src/SpecialFunctions.jl
@@ -2,61 +2,57 @@ __precompile__()
 
 module SpecialFunctions
 
-using Compat
-
-if VERSION >= v"0.6.0-dev.2767"
-    if isdefined(Base, :airyai) && VERSION < v"0.7.0-DEV.986" #22763
-        import Base: airyai, airyaix, airyaiprime, airyaiprimex,
-                     airybi, airybix, airybiprime, airybiprimex,
-                     besselh, besselhx, besseli, besselix, besselj, besselj0, besselj1,
-                     besseljx, besselk, besselkx, bessely, bessely0, bessely1, besselyx,
-                     hankelh1, hankelh1x, hankelh2, hankelh2x,
-                     dawson, erf, erfc, erfcinv, erfcx, erfi, erfinv,
-                     eta, digamma, invdigamma, polygamma, trigamma, zeta,
-                     # deprecated
-                     airy, airyx, airyprime
-    else
-        export
-            airyai,
-            airyaiprime,
-            airybi,
-            airybiprime,
-            airyaix,
-            airyaiprimex,
-            airybix,
-            airybiprimex,
-            besselh,
-            besselhx,
-            besseli,
-            besselix,
-            besselj,
-            besselj0,
-            besselj1,
-            besseljx,
-            besselk,
-            besselkx,
-            bessely,
-            bessely0,
-            bessely1,
-            besselyx,
-            dawson,
-            erf,
-            erfc,
-            erfcinv,
-            erfcx,
-            erfi,
-            erfinv,
-            eta,
-            digamma,
-            invdigamma,
-            polygamma,
-            trigamma,
-            hankelh1,
-            hankelh1x,
-            hankelh2,
-            hankelh2x,
-            zeta
-    end
+if isdefined(Base, :airyai) && VERSION < v"0.7.0-DEV.986" #22763
+    import Base: airyai, airyaix, airyaiprime, airyaiprimex,
+                 airybi, airybix, airybiprime, airybiprimex,
+                 besselh, besselhx, besseli, besselix, besselj, besselj0, besselj1,
+                 besseljx, besselk, besselkx, bessely, bessely0, bessely1, besselyx,
+                 hankelh1, hankelh1x, hankelh2, hankelh2x,
+                 dawson, erf, erfc, erfcinv, erfcx, erfi, erfinv,
+                 eta, digamma, invdigamma, polygamma, trigamma, zeta,
+                 # deprecated
+                 airy, airyx, airyprime
+else
+    export
+        airyai,
+        airyaiprime,
+        airybi,
+        airybiprime,
+        airyaix,
+        airyaiprimex,
+        airybix,
+        airybiprimex,
+        besselh,
+        besselhx,
+        besseli,
+        besselix,
+        besselj,
+        besselj0,
+        besselj1,
+        besseljx,
+        besselk,
+        besselkx,
+        bessely,
+        bessely0,
+        bessely1,
+        besselyx,
+        dawson,
+        erf,
+        erfc,
+        erfcinv,
+        erfcx,
+        erfi,
+        erfinv,
+        eta,
+        digamma,
+        invdigamma,
+        polygamma,
+        trigamma,
+        hankelh1,
+        hankelh1x,
+        hankelh2,
+        hankelh2x,
+        zeta
 end
 
 export sinint,
@@ -66,6 +62,13 @@ if isdefined(Base.Math, :openspecfun)
     const openspecfun = Base.Math.openspecfun
 else
     const openspecfun = "libopenspecfun"
+end
+
+# Avoids a deprecation warning for the 0-arg case on 0.7
+if VERSION < v"0.7.0-DEV.924"
+    const DomainErrorNoArgs = DomainError()
+else
+    const DomainErrorNoArgs = DomainError(nothing)
 end
 
 include("bessel.jl")

--- a/src/bessel.jl
+++ b/src/bessel.jl
@@ -2,7 +2,7 @@
 
 using Base.Math: nan_dom_err
 
-type AmosException <: Exception
+struct AmosException <: Exception
     info::Int32
 end
 
@@ -112,11 +112,11 @@ for afn in (:airyai, :airyaiprime, :airybi, :airybiprime,
             :airyaix, :airyaiprimex, :airybix, :airybiprimex)
     @eval begin
         $afn(z::Complex) = $afn(float(z))
-        $afn{T<:AbstractFloat}(z::Complex{T}) = throw(MethodError($afn,(z,)))
+        $afn(z::Complex{<:AbstractFloat}) = throw(MethodError($afn,(z,)))
         $afn(z::Complex64) = Complex64($afn(Complex128(z)))
     end
     if afn in (:airyaix, :airyaiprimex)
-        @eval $afn(x::Real) = x < 0 ? throw(DomainError()) : real($afn(complex(float(x))))
+        @eval $afn(x::Real) = x < 0 ? throw(DomainErrorNoArgs) : real($afn(complex(float(x))))
     else
         @eval $afn(x::Real) = real($afn(complex(float(x))))
     end
@@ -312,13 +312,13 @@ besselkx(nu::Float64, z::Complex128) = _besselk(abs(nu), z, Int32(2))
 
 function bessely(nu::Cint, x::Float64)
     if x < 0
-        throw(DomainError())
+        throw(DomainErrorNoArgs)
     end
     ccall((:yn, libm), Float64, (Cint, Float64), nu, x)
 end
 function bessely(nu::Cint, x::Float32)
     if x < 0
-        throw(DomainError())
+        throw(DomainErrorNoArgs)
     end
     ccall((:ynf, libm), Float32, (Cint, Float32), nu, x)
 end
@@ -346,7 +346,7 @@ Modified Bessel function of the first kind of order `nu`, ``I_\\nu(x)``.
 """
 function besseli(nu::Real, x::AbstractFloat)
     if x < 0 && !isinteger(nu)
-        throw(DomainError())
+        throw(DomainErrorNoArgs)
     end
     real(besseli(float(nu), complex(x)))
 end
@@ -358,7 +358,7 @@ Scaled modified Bessel function of the first kind of order `nu`, ``I_\\nu(x) e^{
 """
 function besselix(nu::Real, x::AbstractFloat)
     if x < 0 && !isinteger(nu)
-        throw(DomainError())
+        throw(DomainErrorNoArgs)
     end
     real(besselix(float(nu), complex(x)))
 end
@@ -374,7 +374,7 @@ function besselj(nu::Real, x::AbstractFloat)
             return besselj(Cint(nu), x)
         end
     elseif x < 0
-        throw(DomainError())
+        throw(DomainErrorNoArgs)
     end
     real(besselj(float(nu), complex(x)))
 end
@@ -386,7 +386,7 @@ Scaled Bessel function of the first kind of order `nu`, ``J_\\nu(x) e^{- | \\ope
 """
 function besseljx(nu::Real, x::AbstractFloat)
     if x < 0 && !isinteger(nu)
-        throw(DomainError())
+        throw(DomainErrorNoArgs)
     end
     real(besseljx(float(nu), complex(x)))
 end
@@ -398,7 +398,7 @@ Modified Bessel function of the second kind of order `nu`, ``K_\\nu(x)``.
 """
 function besselk(nu::Real, x::AbstractFloat)
     if x < 0
-        throw(DomainError())
+        throw(DomainErrorNoArgs)
     elseif x == 0
         return oftype(x, Inf)
     end
@@ -412,7 +412,7 @@ Scaled modified Bessel function of the second kind of order `nu`, ``K_\\nu(x) e^
 """
 function besselkx(nu::Real, x::AbstractFloat)
     if x < 0
-        throw(DomainError())
+        throw(DomainErrorNoArgs)
     elseif x == 0
         return oftype(x, Inf)
     end
@@ -426,7 +426,7 @@ Bessel function of the second kind of order `nu`, ``Y_\\nu(x)``.
 """
 function bessely(nu::Real, x::AbstractFloat)
     if x < 0
-        throw(DomainError())
+        throw(DomainErrorNoArgs)
     elseif isinteger(nu) && typemin(Cint) <= nu <= typemax(Cint)
         return bessely(Cint(nu), x)
     end
@@ -441,7 +441,7 @@ Scaled Bessel function of the second kind of order `nu`,
 """
 function besselyx(nu::Real, x::AbstractFloat)
     if x < 0
-        throw(DomainError())
+        throw(DomainErrorNoArgs)
     end
     real(besselyx(float(nu), complex(x)))
 end
@@ -454,7 +454,7 @@ for f in ("i", "ix", "j", "jx", "k", "kx", "y", "yx")
             Tf = promote_type(float(typeof(nu)),float(typeof(real(z))))
             $bfn(Tf(nu), Complex{Tf}(z))
         end
-        $bfn{T<:AbstractFloat}(k::T, z::Complex{T}) = throw(MethodError($bfn,(k,z)))
+        $bfn(k::T, z::Complex{T}) where {T<:AbstractFloat} = throw(MethodError($bfn,(k,z)))
         $bfn(nu::Float32, x::Complex64) = Complex64($bfn(Float64(nu), Complex128(x)))
     end
 end
@@ -471,7 +471,7 @@ for bfn in (:besselh, :besselhx)
             $bfn(Tf(nu), k, Complex{Tf}(z))
         end
 
-        $bfn{T<:AbstractFloat}(nu::T, k::Integer, z::Complex{T}) = throw(MethodError($bfn,(nu,k,z)))
+        $bfn(nu::T, k::Integer, z::Complex{T}) where {T<:AbstractFloat} = throw(MethodError($bfn,(nu,k,z)))
         $bfn(nu::Float32, k::Integer, x::Complex64) = Complex64($bfn(Float64(nu), k, Complex128(x)))
     end
 end
@@ -511,7 +511,7 @@ Bessel function of the second kind of order 0, ``Y_0(x)``.
 """
 function bessely0(x::BigFloat)
     if x < 0
-        throw(DomainError())
+        throw(DomainErrorNoArgs)
     end
     z = BigFloat()
     ccall((:mpfr_y0, :libmpfr), Int32, (Ptr{BigFloat}, Ptr{BigFloat}, Int32), &z, &x, ROUNDING_MODE[])
@@ -525,7 +525,7 @@ Bessel function of the second kind of order 1, ``Y_1(x)``.
 """
 function bessely1(x::BigFloat)
     if x < 0
-        throw(DomainError())
+        throw(DomainErrorNoArgs)
     end
     z = BigFloat()
     ccall((:mpfr_y1, :libmpfr), Int32, (Ptr{BigFloat}, Ptr{BigFloat}, Int32), &z, &x, ROUNDING_MODE[])
@@ -534,7 +534,7 @@ end
 
 function bessely(n::Integer, x::BigFloat)
     if x < 0
-        throw(DomainError())
+        throw(DomainErrorNoArgs)
     end
     z = BigFloat()
     ccall((:mpfr_yn, :libmpfr), Int32, (Ptr{BigFloat}, Clong, Ptr{BigFloat}, Int32), &z, n, &x, ROUNDING_MODE[])

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,31 +1,11 @@
 # This file contains code that was formerly a part of Julia. License is MIT: http://julialang.org/license
 
-using Base: @deprecate, depwarn
-using Compat: @dep_vectorize_1arg, @dep_vectorize_2arg
-
-for f in (:digamma, :trigamma, :zeta, :eta, :erfcx, :erfi, :dawson, :airyai, :airyaiprime,
-          :airybi, :airybiprime, :besselj0, :besselj1, :bessely0, :bessely1, :erf, :erfc)
-    @eval @dep_vectorize_1arg Number $f
-end
-
-for f in (:invdigamma, :erfinc, :erfcinv)
-    @eval @dep_vectorize_1arg Real $f
-end
-
-for f in (:polygamma, :zeta, :besseli, :besselix, :besselj, :besseljx, :besselk, :besselkx,
-          :bessely, :besselyx, :besselh, :besselhx, :hankelh1, :hankelh2, :hankelh1x, :hankelh2x)
-    @eval @dep_vectorize_2arg Number $f
-end
-
 @deprecate airy(z::Number) airyai(z)
 @deprecate airyx(z::Number) airyaix(z)
 @deprecate airyprime(z::Number) airyaiprime(z)
-@deprecate airy{T<:Number}(x::AbstractArray{T}) airyai.(x)
-@deprecate airyx{T<:Number}(x::AbstractArray{T}) airyaix.(x)
-@deprecate airyprime{T<:Number}(x::AbstractArray{T}) airyprime.(x)
 
 function _airy(k::Integer, z::Complex128)
-    depwarn("`airy(k,x)` is deprecated, use `airyai(x)`, `airyaiprime(x)`, `airybi(x)` or `airybiprime(x)` instead.",:airy)
+    Base.depwarn("`airy(k,x)` is deprecated, use `airyai(x)`, `airyaiprime(x)`, `airybi(x)` or `airybiprime(x)` instead.",:airy)
     id = Int32(k==1 || k==3)
     if k == 0 || k == 1
         return _airy(z, id, Int32(1))
@@ -36,7 +16,7 @@ function _airy(k::Integer, z::Complex128)
     end
 end
 function _airyx(k::Integer, z::Complex128)
-    depwarn("`airyx(k,x)` is deprecated, use `airyaix(x)`, `airyaiprimex(x)`, `airybix(x)` or `airybiprimex(x)` instead.",:airyx)
+    Base.depwarn("`airyx(k,x)` is deprecated, use `airyaix(x)`, `airyaiprimex(x)`, `airybix(x)` or `airybiprimex(x)` instead.",:airyx)
     id = Int32(k==1 || k==3)
     if k == 0 || k == 1
         return _airy(z, id, Int32(2))
@@ -54,24 +34,14 @@ for afn in (:airy,:airyx)
         function $afn(k::Integer, z::Complex128)
             afn = $(QuoteNode(afn))
             suf = $(QuoteNode(suf))
-            depwarn("`$afn(k,x)` is deprecated, use `airyai$suf(x)`, `airyaiprime$suf(x)`, `airybi$suf(x)` or `airybiprime$suf(x)` instead.",$(QuoteNode(afn)))
+            Base.depwarn("`$afn(k,x)` is deprecated, use `airyai$suf(x)`, `airyaiprime$suf(x)`, `airybi$suf(x)` or `airybiprime$suf(x)` instead.",$(QuoteNode(afn)))
             $_afn(k,z)
         end
 
         $afn(k::Integer, z::Complex) = $afn(k, float(z))
-        $afn{T<:AbstractFloat}(k::Integer, z::Complex{T}) = throw(MethodError($afn,(k,z)))
+        $afn(k::Integer, z::Complex{<:AbstractFloat}) = throw(MethodError($afn,(k,z)))
         $afn(k::Integer, z::Complex64) = Complex64($afn(k, Complex128(z)))
         $afn(k::Integer, x::Real) = $afn(k, float(x))
         $afn(k::Integer, x::AbstractFloat) = real($afn(k, complex(x)))
-
-        function $afn{T<:Number}(k::Number, x::AbstractArray{T})
-            $afn.(k,x)
-        end
-        function $afn{S<:Number}(k::AbstractArray{S}, x::Number)
-            $afn.(k,x)
-        end
-        function $afn{S<:Number,T<:Number}(k::AbstractArray{S}, x::AbstractArray{T})
-            $afn.(k,x)
-        end
     end
 end

--- a/src/erf.jl
+++ b/src/erf.jl
@@ -93,7 +93,7 @@ function erfinv(x::Float64)
         elseif x == -1.0
             return -Inf
         end
-        throw(DomainError())
+        throw(DomainErrorNoArgs)
     elseif a <= 0.75 # Table 17 in Blair et al.
         t = x*x - 0.5625
         return x * @horner(t, 0.16030_49558_44066_229311e2,
@@ -161,7 +161,7 @@ function erfinv(x::Float32)
         elseif x == -1.0f0
             return -Inf32
         end
-        throw(DomainError())
+        throw(DomainErrorNoArgs)
     elseif a <= 0.75f0 # Table 10 in Blair et al.
         t = x*x - 0.5625f0
         return x * @horner(t, -0.13095_99674_22f2,
@@ -213,7 +213,7 @@ function erfcinv(y::Float64)
         if y == 0.0
             return Inf
         end
-        throw(DomainError())
+        throw(DomainErrorNoArgs)
     elseif y >= 1e-100 # Table 57 in Blair et al.
         t = 1.0 / sqrt(-log(y))
         return @horner(t, 0.10501_31152_37334_38116e-3,
@@ -265,7 +265,7 @@ function erfcinv(y::Float32)
         if y == 0.0f0
             return Inf32
         end
-        throw(DomainError())
+        throw(DomainErrorNoArgs)
     else # Table 50 in Blair et al.
         t = 1.0f0 / sqrt(-log(y))
         return @horner(t, 0.15504_70003_116f0,

--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -2,7 +2,7 @@
 
 using Base.MPFR: ROUNDING_MODE, big_ln2
 
-@compat ComplexOrReal{T} = Union{T,Complex{T}}
+const ComplexOrReal{T} = Union{T,Complex{T}}
 
 # Bernoulli numbers B_{2k}, using tabulated numerators and denominators from
 # the online encyclopedia of integer sequences.  (They actually have data
@@ -127,7 +127,7 @@ function cotderiv(m::Integer, z)
     isinf(imag(z)) && return zero(z)
     if m <= 0
         m == 0 && return π * cot(π*z)
-        throw(DomainError())
+        throw(DomainErrorNoArgs)
     end
     if m <= length(cotderiv_Q)
         q = cotderiv_Q[m]
@@ -235,7 +235,7 @@ function zeta(s::ComplexOrReal{Float64}, z::ComplexOrReal{Float64})
             end
             x > 0 && imag(z) == 0 && imag(s) == 0 && return oftype(ζ, Inf)
         end
-        throw(DomainError()) # nothing clever to return
+        throw(DomainErrorNoArgs) # nothing clever to return
     end
     if isnan(x)
         if imag(z)==0 && imag(s)==0
@@ -338,8 +338,8 @@ function polygamma(m::Integer, z::ComplexOrReal{Float64})
     # here works in this case.  m < 0 polygamma is called a
     # "negapolygamma" function in the literature, and there are
     # multiple possible definitions arising from different integration
-    # constants. We throw a DomainError() since the definition is unclear.
-    real(m) < 0 && throw(DomainError())
+    # constants. We throw a DomainError since the definition is unclear.
+    real(m) < 0 && throw(DomainErrorNoArgs)
 
     s = Float64(m+1)
     # It is safe to convert any integer (including `BigInt`) to a float here

--- a/src/sincosint.jl
+++ b/src/sincosint.jl
@@ -120,7 +120,7 @@ function cosint(x::Float64)
     r01, r02 = 0.6162109375, 0.29454812071623379711E-3
     r11, r12 = 3.3837890625, 0.39136005118642639785E-3
     if x < 0.0
-        return throw(DomainError())
+        throw(DomainErrorNoArgs)
     elseif x ≤ 3.0
         return log(x/r0) + ((x - r01) - r02) * (x + r0) *
                                        @horner(t, -0.24607411378767540707E0,


### PR DESCRIPTION
Summary of changes:
* Raise minimum Julia version to 0.6
* Fix deprecation warnings on 0.7 for parametric syntax and type declarations
* Remove some now unnecessary version checks
* Remove dependency on Compat
* Remove 0.5 from the CI testing
* Delete implicit vectorization deprecations (fixes #38)
* Work around 0-arg `DomainError` deprecation on 0.7