### PR TITLE
Use OS and arch only instead of triplets

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -17,22 +17,22 @@ const URL = "https://github.com/ararslan/openspecfun-builder/releases/download/v
             "/libopenspecfun-$OSF_VERS"
 
 const DOWNLOADS = Dict(
-    "x86_64-pc-linux-gnu" => ("$URL-linux-x86_64.tar.gz",
-                              "d70a2a391915f64f44da21915bf93ce08d054127028088addca36e16ac53bcb1"),
-    "i686-pc-linux-gnu"   => ("$URL-linux-i686.tar.gz",
-                              "e5418b170b537af2f7f1f1d06eee9be01555404f5d22a47e18bc06a540321478"),
-    "x86_64-apple-darwin" => ("$URL-osx-x86_64.tar.gz",
-                              "e57f5f84439757a2fd1d3821a6e19a3fa69b5b1e181cc40fec0d1652fbb9efdc"),
-    "x86_64-w64-mingw32"  => ("$URL-win-x86_64.zip",
-                              "7a5f7be4ed46d7f9d6d18a599157075512c50a372da2b2908079a3dcab9a0f25"),
-    "i686-w64-mingw32"    => ("$URL-win-i686.zip",
-                              "2f63a08d80e67964e2c368367f4caef7039080828e217d288669416cd46f4584"),
+    "Linux-x86_64"   => ("$URL-linux-x86_64.tar.gz",
+                         "d70a2a391915f64f44da21915bf93ce08d054127028088addca36e16ac53bcb1"),
+    "Linux-i686"     => ("$URL-linux-i686.tar.gz",
+                         "e5418b170b537af2f7f1f1d06eee9be01555404f5d22a47e18bc06a540321478"),
+    "Darwin-x86_64"  => ("$URL-osx-x86_64.tar.gz",
+                         "e57f5f84439757a2fd1d3821a6e19a3fa69b5b1e181cc40fec0d1652fbb9efdc"),
+    "Windows-x86_64" => ("$URL-win-x86_64.zip",
+                         "7a5f7be4ed46d7f9d6d18a599157075512c50a372da2b2908079a3dcab9a0f25"),
+    "Windows-i686"   => ("$URL-win-i686.zip",
+                         "2f63a08d80e67964e2c368367f4caef7039080828e217d288669416cd46f4584"),
 )
 
-const MACHINE = Compat.Sys.isapple() ? "x86_64-apple-darwin" : Sys.MACHINE
+const SYSTEM = string(BinDeps.OSNAME, '-', Sys.ARCH)
 
-if haskey(DOWNLOADS, MACHINE)
-    url, sha = DOWNLOADS[MACHINE]
+if haskey(DOWNLOADS, SYSTEM)
+    url, sha = DOWNLOADS[SYSTEM]
     provides(Binaries, URI(url), openspecfun, SHA=sha, os=BinDeps.OSNAME,
              unpacked_dir=joinpath("usr", "lib"), installed_libpath=libdir(openspecfun))
 else

--- a/deps/scratch.jl
+++ b/deps/scratch.jl
@@ -17,7 +17,7 @@ if libm == "libopenlibm"
 
     # Copy over the OpenLibm .so
     cp(openlibm_so, joinpath(libdir(openspecfun), basename(openlibm_so)),
-       remove_destination=true)
+       remove_destination=true, follow_symlinks=true)
 
     if !isdir(srcdir(openspecfun))
         mkpath(srcdir(openspecfun))
@@ -43,12 +43,12 @@ if libm == "libopenlibm"
     end
     for f in readdir(joinpath(openlibm_src, "include"))
         cp(joinpath(openlibm_src, "include", f), joinpath(openlibm_include, f),
-           remove_destination=true)
+           remove_destination=true, follow_symlinks=true)
     end
     for f in readdir(joinpath(openlibm_src, "src"))
         if endswith(f, ".h")
             cp(joinpath(openlibm_src, "src", f), joinpath(openlibm_include, f),
-               remove_destination=true)
+               remove_destination=true, follow_symlinks=true)
         end
     end
 else


### PR DESCRIPTION
@colbec, @H-M-H, @TomCab: Can you try
```julia
Pkg.checkout("SpecialFunctions")
Pkg.checkout("SpecialFunctions", "aa/no-triplets")
Pkg.build("SpecialFunctions")
using SpecialFunctions
```
and tell me whether it works for you?