### PR TITLE
Improve build logic to identify when to build from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ Special mathematical functions in Julia, including Bessel, Hankel, Airy, error, 
 eta, zeta, digamma, inverse digamma, trigamma, and polygamma functions.
 Most of these functions were formerly part of Base.
 
+Note: On Julia 0.7, this package downloads and/or builds
+[openspecfun](https://github.com/JuliaLang/openspecfun), which is no longer built as part
+of Julia.
+Binaries are available for macOS, Windows, and Linux (glibc >= 2.6).
+To force compilation of the library from source, set an environment variable called
+`JULIA_SPECIALFUNCTIONS_BUILD_SOURCE` equal to `true` before running `Pkg.build`.
+
 [![Travis](https://travis-ci.org/JuliaMath/SpecialFunctions.jl.svg?branch=master)](https://travis-ci.org/JuliaMath/SpecialFunctions.jl)
 [![AppVeyor](https://ci.appveyor.com/api/projects/status/ccfgkm2cjcggu158/branch/master?svg=true)](https://ci.appveyor.com/project/ararslan/specialfunctions-jl/branch/master)
 [![Coverage Status](https://coveralls.io/repos/github/JuliaMath/SpecialFunctions.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaMath/SpecialFunctions.jl?branch=master)

--- a/deps/binaries.jl
+++ b/deps/binaries.jl
@@ -1,0 +1,48 @@
+using BinDeps, Compat
+using BinDeps: libdir
+
+modified_defaults = false
+if !in(BinDeps.Binaries, BinDeps.defaults)
+    unshift!(BinDeps.defaults, BinDeps.Binaries)
+    modified_defaults = true
+end
+
+BinDeps.@setup
+did_setup = true
+
+const OSF_VERS = v"0.5.3"
+
+openspecfun = library_dependency("libopenspecfun")
+
+const URL = "https://github.com/ararslan/openspecfun-builder/releases/download/v$OSF_VERS" *
+            "/libopenspecfun-$OSF_VERS"
+
+const DOWNLOADS = Dict(
+    "Linux-x86_64"   => ("$URL-linux-x86_64.tar.gz",
+                         "d70a2a391915f64f44da21915bf93ce08d054127028088addca36e16ac53bcb1"),
+    "Linux-i686"     => ("$URL-linux-i686.tar.gz",
+                         "e5418b170b537af2f7f1f1d06eee9be01555404f5d22a47e18bc06a540321478"),
+    "Darwin-x86_64"  => ("$URL-osx-x86_64.tar.gz",
+                         "e57f5f84439757a2fd1d3821a6e19a3fa69b5b1e181cc40fec0d1652fbb9efdc"),
+    "Windows-x86_64" => ("$URL-win-x86_64.zip",
+                         "7a5f7be4ed46d7f9d6d18a599157075512c50a372da2b2908079a3dcab9a0f25"),
+    "Windows-i686"   => ("$URL-win-i686.zip",
+                         "2f63a08d80e67964e2c368367f4caef7039080828e217d288669416cd46f4584"),
+)
+
+const SYSTEM = string(BinDeps.OSNAME, '-', Sys.ARCH)
+
+if haskey(DOWNLOADS, SYSTEM)
+    url, sha = DOWNLOADS[SYSTEM]
+    provides(Binaries, URI(url), openspecfun, SHA=sha, os=BinDeps.OSNAME,
+             unpacked_dir=joinpath("usr", "lib"), installed_libpath=libdir(openspecfun))
+else
+    info("No precompiled binaries found for your system. Building from scratch...")
+    include("scratch.jl")
+end
+
+BinDeps.@install Dict(:libopenspecfun => :openspecfun)
+
+if modified_defaults
+    shift!(BinDeps.defaults)
+end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,47 +1,34 @@
-using BinDeps, Compat
-using BinDeps: libdir, srcdir, includedir, depsdir, builddir
+using Compat
+using Compat.Sys: isapple, islinux, iswindows
 
-modified_defaults = false
-if !in(BinDeps.Binaries, BinDeps.defaults)
-    unshift!(BinDeps.defaults, BinDeps.Binaries)
-    modified_defaults = true
-end
+did_setup = false
 
-BinDeps.@setup
-
-const OSF_VERS = v"0.5.3"
-
-openspecfun = library_dependency("libopenspecfun")
-
-const URL = "https://github.com/ararslan/openspecfun-builder/releases/download/v$OSF_VERS" *
-            "/libopenspecfun-$OSF_VERS"
-
-const DOWNLOADS = Dict(
-    "Linux-x86_64"   => ("$URL-linux-x86_64.tar.gz",
-                         "d70a2a391915f64f44da21915bf93ce08d054127028088addca36e16ac53bcb1"),
-    "Linux-i686"     => ("$URL-linux-i686.tar.gz",
-                         "e5418b170b537af2f7f1f1d06eee9be01555404f5d22a47e18bc06a540321478"),
-    "Darwin-x86_64"  => ("$URL-osx-x86_64.tar.gz",
-                         "e57f5f84439757a2fd1d3821a6e19a3fa69b5b1e181cc40fec0d1652fbb9efdc"),
-    "Windows-x86_64" => ("$URL-win-x86_64.zip",
-                         "7a5f7be4ed46d7f9d6d18a599157075512c50a372da2b2908079a3dcab9a0f25"),
-    "Windows-i686"   => ("$URL-win-i686.zip",
-                         "2f63a08d80e67964e2c368367f4caef7039080828e217d288669416cd46f4584"),
-)
-
-const SYSTEM = string(BinDeps.OSNAME, '-', Sys.ARCH)
-
-if haskey(DOWNLOADS, SYSTEM)
-    url, sha = DOWNLOADS[SYSTEM]
-    provides(Binaries, URI(url), openspecfun, SHA=sha, os=BinDeps.OSNAME,
-             unpacked_dir=joinpath("usr", "lib"), installed_libpath=libdir(openspecfun))
-else
-    info("No precompiled binaries found for your system. Building from scratch...")
+if VERSION < v"0.7.0-DEV.1760"
+    # No need to build or download anything; openspecfun is part of Julia
+elseif get(ENV, "JULIA_SPECIALFUNCTIONS_BUILD_SOURCE", "false") == "true"
+    # Allow a fast-path for building from source
+    info("Building openspecfun from source by request")
     include("scratch.jl")
-end
-
-BinDeps.@install Dict(:libopenspecfun => :openspecfun)
-
-if modified_defaults
-    shift!(BinDeps.defaults)
+elseif isapple() || iswindows()
+    # Windows and macOS can always use our binaries, and we have no binaries
+    # for other non-Linux systems (e.g. BSDs)
+    include("binaries.jl")
+elseif !islinux()
+    include("scratch.jl")
+else # linux
+    # Determine the glibc version. If the check fails, we know we're on a non-glibc
+    # system, which means we can't use the binaries and need to build from source.
+    # The glibc version used by the binaries is 2.6, so we need at least that.
+    libc_ptr = ccall(:jl_dlopen, Ptr{Void}, (Ptr{Void}, UInt32), C_NULL, 0)
+    glibc_ptr = Libdl.dlsym_e(libc_ptr, :gnu_get_libc_version)
+    if glibc_ptr == C_NULL
+        include("scratch.jl")
+    else
+        glibc_vers = unsafe_string(ccall(glibc_ptr, Ptr{UInt8}, ()))
+        if isempty(glibc_vers) || VersionNumber(glibc_vers) < v"2.6.0"
+            include("scratch.jl")
+        else
+            include("binaries.jl")
+        end
+    end
 end

--- a/deps/scratch.jl
+++ b/deps/scratch.jl
@@ -1,6 +1,15 @@
 # Building OpenSpecFun from scratch
 
+using BinDeps
+using BinDeps: libdir, srcdir, includedir, depsdir, builddir
 using Base.Math: libm
+
+# Don't call setup again if we're being included from binaries.jl
+if !did_setup
+    BinDeps.@setup
+    const OSF_VERS = v"0.5.3"
+    openspecfun = library_dependency("libopenspecfun")
+end
 
 # If Julia is built with OpenLibm, we want to build OpenSpecFun with it as well.
 # Unfortunately this requires a fair bit more work, as we need to link to the .so
@@ -110,3 +119,9 @@ provides(BuildProcess,
                 end)
         end
     end), openspecfun)
+
+# If we're being included, the installation step happens once we return back
+# to binaries.jl
+if !did_setup
+    BinDeps.@install Dict(:libopenspecfun => :openspecfun)
+end

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -59,3 +59,22 @@ to avoid name conflicts.
 In this case, the symbols will need to be explicitly imported or called
 with the prefix `SpecialFunctions`.
 This is not necessary for Julia versions 0.6 and later.
+
+On Julia 0.7, [openspecfun](https://github.com/JuliaLang/openspecfun) is not build as
+part of Julia.
+Thus for Julia versions 0.7 and later, installing this package downloads openspecfun.
+Binaries of openspecfun are available for macOS, Windows, and Linux (glibc >= 2.6).
+Other systems will need to build the library from source.
+You can force a build from source by setting an environment variable called
+`JULIA_SPECIALFUNCTIONS_BUILD_SOURCE` equal to `true` before running `Pkg.build`.
+This ensures that the library is built locally from source, even if binaries are
+available.
+Doing this requires a C compiler (Clang on macOS and FreeBSD, GCC elsewhere) and
+gfortran.
+If you always want to build this library from source, consider adding
+
+```julia
+ENV["JULIA_SPECIALFUNCTIONS_BUILD_SOURCE"] = "true"
+```
+
+to your .juliarc.jl file.

--- a/src/SpecialFunctions.jl
+++ b/src/SpecialFunctions.jl
@@ -4,13 +4,16 @@ module SpecialFunctions
 
 using Compat
 
-let depsfile = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
+if VERSION >= v"0.7.0-DEV.1760"
+    depsfile = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
     if isfile(depsfile)
         include(depsfile)
     else
         error("SpecialFunctions is not properly installed. Please run " *
               "Pkg.build(\"SpecialFunctions\") and restart Julia.")
     end
+else
+    using Base.Math: openspecfun
 end
 
 if isdefined(Base, :airyai) && VERSION < v"0.7.0-DEV.986" #22763

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,12 @@
 # This file contains code that was formerly a part of Julia. License is MIT: http://julialang.org/license
 
 using SpecialFunctions
-using Base.Test
+
+if isdefined(Base, :Test) && !Base.isdeprecated(Base, :Test)
+    using Base.Test
+else
+    using Test
+end
 
 const SF = SpecialFunctions
 


### PR DESCRIPTION
This ensures that:
* We don't build or download anything unnecessarily on 0.6
* We can build from source upon request
* We don't use binaries for non-glibc Linux
* We don't use binaries for Linux with prehistoric glibc

Fixes #56 and addresses @tkelman's concerns about non-glibc Linux.