### PR TITLE
Silence warnings when testing on v0.7.0-DEV

### DIFF
--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -100,13 +100,13 @@ function cotderiv_q(m::Int)
     q₋ = cotderiv_q(m-1)
     d = length(q₋) - 1 # degree of q₋
     if isodd(m-1)
-        q = Vector{Float64}(uninitialized, length(q₋))
+        q = Vector{Float64}(undef, length(q₋))
         q[end] = d * q₋[end] * 2/m
         for i = 1:length(q)-1
             q[i] = ((i-1)*q₋[i] + i*q₋[i+1]) * 2/m
         end
     else # iseven(m-1)
-        q = Vector{Float64}(uninitialized, length(q₋) + 1)
+        q = Vector{Float64}(undef, length(q₋) + 1)
         q[1] = q₋[1] / m
         q[end] = (1 + 2d) * q₋[end] / m
         for i = 2:length(q)-1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,7 +40,7 @@ relerrc(z, x) = max(relerr(real(z),real(x)), relerr(imag(z),imag(x)))
     @test SF.dawson(1+2im) ≈ -13.388927316482919244-11.828715103889593303im
 
     for elty in [Float32,Float64]
-        for x in exp10.(range(-200, stop = -0.01, length = 50))
+        for x in exp10.(Compat.range(-200, stop = -0.01, length = 50))
             @test isapprox(SF.erf(SF.erfinv(x)), x, atol=1e-12*x)
             @test isapprox(SF.erf(SF.erfinv(-x)), -x, atol=1e-12*x)
             @test isapprox(SF.erfc(SF.erfcinv(2*x)), 2*x, atol=1e-12*x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,7 +40,7 @@ relerrc(z, x) = max(relerr(real(z),real(x)), relerr(imag(z),imag(x)))
     @test SF.dawson(1+2im) ≈ -13.388927316482919244-11.828715103889593303im
 
     for elty in [Float32,Float64]
-        for x in logspace(-200, -0.01)
+        for x in exp10.(range(-200, stop = -0.01, length = 50))
             @test isapprox(SF.erf(SF.erfinv(x)), x, atol=1e-12*x)
             @test isapprox(SF.erf(SF.erfinv(-x)), -x, atol=1e-12*x)
             @test isapprox(SF.erfc(SF.erfcinv(2*x)), 2*x, atol=1e-12*x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 # This file contains code that was formerly a part of Julia. License is MIT: http://julialang.org/license
 
-using SpecialFunctions
+using Compat, SpecialFunctions
 
 if isdefined(Base, :Test) && !Base.isdeprecated(Base, :Test)
     using Base.Test


### PR DESCRIPTION
- Replace use of `uninitialized` with `undef`
- Replace use of `logspace` with `exp10.(Compat.range(start, stop=stop, length=50))`