### PR TITLE
Sequence of Bessel/Hankel Functions (multiple order)

### DIFF
--- a/src/SpecialFunctions.jl
+++ b/src/SpecialFunctions.jl
@@ -77,6 +77,4 @@ include("sincosint.jl")
 include("gamma.jl")
 include("deprecated.jl")
 
-export besseljs,
-       besselhs
 end # module

--- a/src/SpecialFunctions.jl
+++ b/src/SpecialFunctions.jl
@@ -77,4 +77,6 @@ include("sincosint.jl")
 include("gamma.jl")
 include("deprecated.jl")
 
+export besseljs,
+       besselhs
 end # module

--- a/src/bessel.jl
+++ b/src/bessel.jl
@@ -642,4 +642,4 @@ end
 
 besselh(nu::UnitRange{Int}, k::Integer, x::Real) = besselh(nu, k, float(x))
 besselh(nu::UnitRange{Int}, k::Integer, x::AbstractFloat) = besselh(nu, k, complex(x))
-besselh(nu::UnitRange{Int}, k::Integer, x::Complex{Float32}) = Complex{Float32}(besselh(nu, k, Complex{Float64}(x)))
+besselh(nu::UnitRange{Int}, k::Integer, x::Complex{Float32}) = Complex{Float32}.(besselh(nu, k, Complex{Float64}(x)))

--- a/src/bessel.jl
+++ b/src/bessel.jl
@@ -625,10 +625,7 @@ function _besselhs(nu::Float64, k::Int32, z::Complex{Float64}, N::Int32)
             real(z), imag(z), nu, Int32(1), k, N,
             ai1, ai2, ae1, ae2)
 
-    if ae2[] == 0
-        return (N == 1 ? complex(ai1[1], ai2[1]) : complex.(ai1, ai2))
-    elseif ae2[] == 3
-        warn("besselh: loss of precision")
+    if ae2[] == 0 || ae2[] == 3
         return (N == 1 ? complex(ai1[1], ai2[1]) : complex.(ai1, ai2))
     else
         throw(AmosException(ae2[]))
@@ -636,7 +633,7 @@ function _besselhs(nu::Float64, k::Int32, z::Complex{Float64}, N::Int32)
 end
 
 function besselh(nu::Range{T} where T <: Real, k::Integer, z::Complex{Float64})
-    (nu[1] ≥ 0 && step(nu) == 1) || error("nu must be a range with unit step ≥ 0")
+    (nu[1] ≥ 0 && step(nu) == 1) || throw(ArgumentError("nu must be a range with unit step ≥ 0"))
     return _besselhs(Float64(nu[1]), Int32(k), z, Int32(length(nu)))
 end
 

--- a/src/bessel.jl
+++ b/src/bessel.jl
@@ -192,7 +192,7 @@ end
 function _besseli(nu::Float64, z::Complex{Float64}, kode::Int32)
     ai1, ai2 = Ref{Float64}(), Ref{Float64}()
     ae1, ae2 = Ref{Int32}(), Ref{Int32}()
-  
+
     ccall((:zbesi_,openspecfun), Cvoid,
           (Ref{Float64}, Ref{Float64}, Ref{Float64}, Ref{Int32}, Ref{Int32},
            Ref{Float64}, Ref{Float64}, Ref{Int32}, Ref{Int32}),
@@ -215,7 +215,7 @@ function _besselj(nu::Float64, z::Complex{Float64}, kode::Int32)
            Ref{Float64}, Ref{Float64}, Ref{Int32}, Ref{Int32}),
            real(z), imag(z), nu, kode, 1,
            ai1, ai2, ae1, ae2)
-    
+
     if ae2[] == 0 || ae2[] == 3
         return complex(ai1[], ai2[])
     else
@@ -613,3 +613,47 @@ hankelh1x(nu, z) = besselhx(nu, 1, z)
 Scaled Bessel function of the third kind of order `nu`, ``H^{(2)}_\\nu(x) e^{x i}``.
 """
 hankelh2x(nu, z) = besselhx(nu, 2, z)
+
+function besseljs(nu::Integer, z)
+    nu ≥ 0 || error("nu must be an integer ≥ 0")
+    N = Int32(nu + 1)
+    ai1, ai2 = Array{Float64}(N), Array{Float64}(N)
+    ae1, ae2 = Ref{Int32}(), Ref{Int32}()
+
+    ccall((:zbesj_,openspecfun), Cvoid,
+          (Ref{Float64}, Ref{Float64}, Ref{Float64}, Ref{Int32}, Ref{Int32},
+           Ptr{Float64}, Ptr{Float64}, Ref{Int32}, Ref{Int32}),
+           real(z), imag(z), Float64(0), Int32(1), N,
+           ai1, ai2, ae1, ae2)
+
+   if ae2[] == 0
+       return (nu == 0 ? complex(ai1[1], ai2[1]) : complex.(ai1, ai2))
+   elseif ae2[] == 3
+       warn("besselhs: loss of precision")
+       return (nu == 0 ? complex(ai1[1], ai2[1]) : complex.(ai1, ai2))
+   else
+       throw(AmosException(ae2[]))
+   end
+end
+
+function besselhs(nu::Integer, k::Integer, z)
+    nu ≥ 0 || error("nu must be an integer ≥ 0")
+    N = Int32(nu + 1)
+    ai1, ai2 = Array{Float64}(N), Array{Float64}(N)
+    ae1, ae2 = Ref{Int32}(), Ref{Int32}()
+
+    ccall((:zbesh_,openspecfun), Cvoid,
+           (Ref{Float64}, Ref{Float64}, Ref{Float64}, Ref{Int32}, Ref{Int32}, Ref{Int},
+            Ptr{Float64}, Ref{Float64}, Ref{Int32}, Ref{Int32}),
+            real(z), imag(z), Float64(0), Int32(1), Int32(k), N,
+            ai1, ai2, ae1, ae2)
+
+    if ae2[] == 0
+        return (nu == 0 ? complex(ai1[1], ai2[1]) : complex.(ai1, ai2))
+    elseif ae2[] == 3
+        warn("besselhs: loss of precision")
+        return (nu == 0 ? complex(ai1[1], ai2[1]) : complex.(ai1, ai2))
+    else
+        throw(AmosException(ae2[]))
+    end
+end

--- a/src/bessel.jl
+++ b/src/bessel.jl
@@ -263,7 +263,8 @@ end
 
 Bessel function of the third kind of order `nu` (the Hankel function). `k` is either 1 or 2,
 selecting [`hankelh1`](@ref) or [`hankelh2`](@ref), respectively.
-`k` defaults to 1 if it is omitted.
+`k` defaults to 1 if it is omitted. 
+`nu` is either `Real` or a non-negative `Range` with `step == 1`, such as `0.5:3.5` or `0:1`.
 (See also [`besselhx`](@ref) for an exponentially scaled variant.)
 """
 function besselh end

--- a/src/bessel.jl
+++ b/src/bessel.jl
@@ -263,7 +263,7 @@ end
 
 Bessel function of the third kind of order `nu` (the Hankel function). `k` is either 1 or 2,
 selecting [`hankelh1`](@ref) or [`hankelh2`](@ref), respectively.
-`k` defaults to 1 if it is omitted. 
+`k` defaults to 1 if it is omitted.
 `nu` is either `Real` or a non-negative `Range` with `step == 1`, such as `0.5:3.5` or `0:1`.
 (See also [`besselhx`](@ref) for an exponentially scaled variant.)
 """
@@ -616,7 +616,7 @@ Scaled Bessel function of the third kind of order `nu`, ``H^{(2)}_\\nu(x) e^{x i
 hankelh2x(nu, z) = besselhx(nu, 2, z)
 
 function _besselhs(nu::Float64, k::Int32, z::Complex{Float64}, N::Int32)
-    ai1, ai2 = Array{Float64}(N), Array{Float64}(N)
+    ai1, ai2 = Vector{Float64}(undef, N), Vector{Float64}(undef, N)
     ae1, ae2 = Ref{Int32}(), Ref{Int32}()
 
     ccall((:zbesh_,openspecfun), Cvoid,
@@ -632,7 +632,7 @@ function _besselhs(nu::Float64, k::Int32, z::Complex{Float64}, N::Int32)
     end
 end
 
-function besselh(nu::Range{T} where T <: Real, k::Integer, z::Complex{Float64})
+function besselh(nu::AbstractRange{<:Real}, k::Integer, z::Complex{Float64})
     (nu[1] ≥ 0 && step(nu) == 1) || throw(ArgumentError("nu must be a range with unit step ≥ 0"))
     return _besselhs(Float64(nu[1]), Int32(k), z, Int32(length(nu)))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -340,6 +340,7 @@ end
         @test all(SF.besselh(1:3,1,4.0) .≈ h1n4)
         @test SF.besselh(1//2:5//2, 1im)[2] ≈ SF.besselh(1.5, 1.0im)
         @test_throws SF.AmosException SF.besselh(1//2:3.5, 1e10im)
+        @test_throws ArgumentError besselh(-1:1,1)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -330,6 +330,15 @@ end
             @test f(0,1) ≈ f(0,Complex{Float32}(1))
         end
     end
+    @testset "besselh order range" begin
+        true_h114 = -0.066043328023549136143 + 0.397925710557100005254im
+        true_h124 =  0.364128145852072804215 + 0.215903594603614994531im
+        true_h134 =  0.430171473875621940358 - 0.182022115953485010723im
+        h1n4 = SF.besselh(1:3,1,4)
+        @test all(h1n4 .≈ [true_h114; true_h124; true_h134])
+        @test all(SF.besselh(1:3,2,4) .≈ conj(h1n4))
+        @test all(SF.besselh(1:3,1,4.0) .≈ h1n4)
+    end
 end
 
 @testset "gamma and friends" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -338,6 +338,8 @@ end
         @test all(h1n4 .≈ [true_h114; true_h124; true_h134])
         @test all(SF.besselh(1:3,2,4) .≈ conj(h1n4))
         @test all(SF.besselh(1:3,1,4.0) .≈ h1n4)
+        @test SF.besselh(1//2:5//2, 1im)[2] ≈ SF.besselh(1.5, 1.0im)
+        @test_throws SF.AmosException SF.besselh(1//2:3.5, 1e10im)
     end
 end
 


### PR DESCRIPTION
Based on #26, this PR allows the computation of multiple Hankel function orders at once, with the signature:
```julia
besselh(nu::UnitRange{Int}, [k=1], z)
```
where `nu >= 0`.

Please let me know if this addition is acceptable or if any changes are necessary. Once the syntax is finalized I can add similar versions for `besselj`,`besseli`,`besselk`,`bessely` as well as documentation.