### PR TITLE
clean up after failing to use BinaryProvider

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -40,6 +40,9 @@ else
             install(url, tarball_hash; prefix=prefix, force=true, verbose=verbose)
             unsatisfied = any(!satisfied(p; verbose=verbose) for p in products)
         end
+        if unsatisfied
+            rm(joinpath(@__DIR__, "usr", "lib"); force=true, recursive=true)
+        end
     end
 
     if unsatisfied || forcecompile


### PR DESCRIPTION
Otherwise the artifact left behind by BinaryProvider will be seen by BinDeps and BinDeps will not do anything because it think things are satisfied.