### PR TITLE
Add lbinomial function based on lbeta

### DIFF
--- a/src/SpecialFunctions.jl
+++ b/src/SpecialFunctions.jl
@@ -68,7 +68,8 @@ else
 end
 
 export sinint,
-       cosint
+       cosint,
+       lbinomial
 
 include("bessel.jl")
 include("erf.jl")

--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -764,3 +764,25 @@ const lfactorial = lfact
 export lfactorial
 
 end # @static if
+
+"""
+    lbinomial(n, k) = log(abs(binomial(n, k)))
+
+Accurate natural logarithm of the absolute value of the [`binomial`](@ref)
+coefficient `binomial(n, k)` for large `n` and `k` near `n/2`.
+"""
+function lbinomial(n::T, k::T) where {T<:Integer}
+    S = float(T)
+    (k < 0) && return typemin(S)
+    if n < 0
+        n = -n + k - 1
+    end
+    k > n && return typemin(S)
+    (k == 0 || k == n) && return zero(S)
+    (k == 1) && return log(abs(n))
+    if k > (n>>1)
+        k = n - k
+    end
+    -log1p(n) - lbeta(n - k + one(T), k + one(T))
+end
+lbinomial(n::Integer, k::Integer) = lbinomial(promote(n, k)...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -636,3 +636,15 @@ end
 
     @test beta(big(1.0),big(1.2)) ≈ beta(1.0,1.2) rtol=4*eps()
 end
+
+@testset "lbinomial" begin
+    @test lbinomial(10, -1) == -Inf
+    @test lbinomial(10, 11) == -Inf
+    @test lbinomial(10,  0) == 0.0
+    @test lbinomial(10, 10) == 0.0
+
+    @test lbinomial(10,  1)      ≈ log(10)
+    @test lbinomial(-6, 10)      ≈ log(binomial(-6, 10))
+    @test lbinomial(-6, 11)      ≈ log(abs(binomial(-6, 11)))
+    @test lbinomial.(200, 0:200) ≈ log.(binomial.(BigInt(200), (0:200)))
+end


### PR DESCRIPTION
This was originally submitted to base in https://github.com/JuliaLang/julia/pull/27419, but https://github.com/JuliaLang/julia/pull/27473 moved `special/gamma.jl` things here, so I'm making the same PR here now. Details are copied over:

This implementation of `lbinomial` uses the fact that `binomial(n,k) = 1/( (n+1) * B(n - k + 1, k + 1) )`. I have added tests for some simple cases, and then also comparing for very large `n` with `binomial(::BigInt, ::BigInt)`.

The main motivation is evaluating `log(binomial(n,k))` for large `n` with `k` near `n/2` without approximating with Poisson:

```julia
julia> log(binomial(70, 25)) # OK
43.311504703669215

julia> log(binomial(70, 26)) # :(
ERROR: InexactError()
Stacktrace:
 [1] binomial(::Int64, ::Int64) at ./intfuncs.jl:810

julia> log(binomial(BigInt(70), BigInt(26))) # OK, if you can afford it
4.386007065541805521142055198415251198714576775237582336220765505130378175238536e+01

julia> ans - lbinomial(70, 26) # Close enough?
-8.056495743460440321531836165841374176637792344948696218247614638531207882439305e-15
```

In R, this function is available as `lchoose(n, k)` and is a builtin.