### PR TITLE
avoid overwrite warning while the deprecation in Base is still active

### DIFF
--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -754,8 +754,13 @@ end
 @inline lgamma(x::Real) = lgamma(float(x))
 
 ## from base/numbers.jl
-# TODO: deprecate instead of doing this type-piracy here?
-Base.factorial(x::Number) = gamma(x + 1) # fallback for x not Integer
+
+# this trickery is needed while the deprecated method in Base exists
+@static if !hasmethod(Base.factorial, Tuple{Number})
+    import Base: factorial
+end
+factorial(x) = Base.factorial(x) # to make SpecialFunctions.factorial work unconditionally
+factorial(x::Number) = gamma(x + 1) # fallback for x not Integer
 
 else # @static if
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -571,9 +571,9 @@ end
         @test lgamma(1.4+3.7im) ≈ -3.7094025330996841898 + 2.4568090502768651184im
         @test lgamma(1.4+3.7im) ≈ log(gamma(1.4+3.7im))
         @test lgamma(-4.2+0im) ≈ lgamma(-4.2)-5pi*im
-        @test factorial(3.0) == gamma(4.0) == factorial(3)
+        @test SpecialFunctions.factorial(3.0) == gamma(4.0) == factorial(3)
         for x in (3.2, 2+1im, 3//2, 3.2+0.1im)
-            @test factorial(x) == gamma(1+x)
+            @test SpecialFunctions.factorial(x) == gamma(1+x)
         end
         @test lfactorial(0) == lfactorial(1) == 0
         @test lfactorial(2) == lgamma(3)


### PR DESCRIPTION
Avoids this
```
WARNING: Method definition factorial(Number) in module Base at deprecated.jl:1709 overwritten
in module SpecialFunctions at /home/fredrik/.julia/dev/SpecialFunctions/src/gamma.jl:760.
```