### PR TITLE
Set up FreeBSD CI using Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,16 @@
+freebsd_instance:
+  image: freebsd-12-0-release-amd64
+freebsd_test_task:
+  env:
+    JULIA_VERSION: "1.0"
+  install_script:
+    - pkg install -y curl
+    - mkdir -p ~/julia
+    - curl -s -L --retry 7 "https://julialang-s3.julialang.org/bin/freebsd/x64/${JULIA_VERSION}/julia-${JULIA_VERSION}-latest-freebsd-x86_64.tar.gz" | tar -C ~/julia -x -z --strip-components=1 -f -
+    - ln -s "${HOME}/julia/bin/julia" /usr/local/bin/julia
+    - julia --color=yes -e "using InteractiveUtils; versioninfo()"
+  build_script:
+    - julia --color=yes -e "using Pkg; Pkg.add(PackageSpec(name=\"SpecialFunctions\", path=pwd()))"
+    - julia --color=yes -e "using Pkg; Pkg.build(\"SpecialFunctions\")"
+  test_script:
+    - julia --color=yes -e "using Pkg; Pkg.test(\"SpecialFunctions\")"


### PR DESCRIPTION
The package has a binary dependency and supports FreeBSD, so FreeBSD CI seems worthwhile. At least it can't hurt. 🙂 