### PR TITLE
Optimized gamma. Was: Saving gamma: Base._fact_table64 is dangerous

### DIFF
--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -748,7 +748,7 @@ if Base.MPFR.version() >= v"4.0.0"
     end
 end
 
-const _shifted_gamma_fact_table = gamma.(collect(1.0:171.0))
+const _shifted_gamma_fact_table = [Inf; gamma.(collect(1.0:171.0))]
 
 function gamma(n::Union{Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Int128,UInt128})
     if !(0 <= n <= 171) 

--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -748,11 +748,15 @@ if Base.MPFR.version() >= v"4.0.0"
     end
 end
 
-## originally from base/combinatorics.jl (and now optimized and changed to handle upcoming change in Julia)
+const _shifted_gamma_fact_table = [gamma.(collect(1.0:171.0))]
 
 function gamma(n::Union{Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Int128,UInt128})
-    1 <= n <= 21 && return Float64(factorial(n-1))
-    return gamma(Float64(n))
+    if !(0 <= n <= 171) 
+        0 <= n && return Inf
+    else
+        return @inbounds _shifted_gamma_fact_table[(n+1)]
+    end
+    throw(DomainError(n, "`n` must not be negative."))
 end
 
 ## from base/math.jl

--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -750,8 +750,8 @@ end
 
 ## originally from base/combinatorics.jl (and now optimized and changed to handle upcoming change in Julia)
 
-function gamma(n::Union{Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Int128,UInt128})
-    m = n-1; 0 <= m < 16 && return Float64(Base.factorial(Int64(m)))
+function gamma_new(n::Union{Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Int128,UInt128})
+    1 <= n <= 20 && return Float64(factorial(Int64(n-1)))
     return gamma(Float64(n))
 end
 

--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -751,7 +751,7 @@ end
 ## originally from base/combinatorics.jl (and now optimized and changed to handle upcoming change in Julia)
 
 function gamma(n::Union{Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Int128,UInt128})
-    1 <= n <= 21 && return Float64(factorial(Int64(n-1)))
+    1 <= n <= 21 && return Float64(factorial(n-1))
     return gamma(Float64(n))
 end
 

--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -751,7 +751,7 @@ end
 ## originally from base/combinatorics.jl (and now optimized and changed to handle upcoming change in Julia)
 
 function gamma(n::Union{Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Int128,UInt128})
-    m = n-1; 0 <= m < 32 && return Float64(Base.factorial(Int64(m)))
+    m = n-1; 0 <= m < 16 && return Float64(Base.factorial(Int64(m)))
     return gamma(Float64(n))
 end
 

--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -751,7 +751,7 @@ end
 ## originally from base/combinatorics.jl (and now optimized and changed to handle upcoming change in Julia)
 
 function gamma(n::Union{Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Int128,UInt128})
-    m = n-1; 0 <= m < 32 && return Float64(Base.factorial(Int128(m)))
+    m = n-1; 0 <= m < 32 && return Float64(Base.factorial(Int64(m)))
     return gamma(Float64(n))
 end
 

--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -751,11 +751,8 @@ end
 ## from base/combinatorics.jl'
 
 function gamma(n::Union{Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Int128,UInt128})
-    n < 0 && throw(DomainError(n, "`n` must not be negative."))
-    n == 0 && return Inf
-    n <= 2 && return 1.0
     n > 20 && return gamma(Float64(n))
-    return Float64(Base.factorial(n-1))
+    return Float64(Base.factorial(Int64(n-1)))
 end
 
 ## from base/math.jl

--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -750,12 +750,12 @@ end
 
 ## from base/combinatorics.jl'
 
-function gamma(n::Union{Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64})
+function gamma(n::Union{Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Int128,UInt128})
     n < 0 && throw(DomainError(n, "`n` must not be negative."))
     n == 0 && return Inf
     n <= 2 && return 1.0
     n > 20 && return gamma(Float64(n))
-    @inbounds return Float64(Base._fact_table64[n-1])
+    return Float64(Base.factorial(n-1))
 end
 
 ## from base/math.jl

--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -748,11 +748,11 @@ if Base.MPFR.version() >= v"4.0.0"
     end
 end
 
-## from base/combinatorics.jl'
+## originally from base/combinatorics.jl (and now optimized and changed to handle upcoming change in Julia)
 
 function gamma(n::Union{Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Int128,UInt128})
-    n > 20 && return gamma(Float64(n))
-    return Float64(Base.factorial(Int64(n-1)))
+    m = n-1; 0 <= m < 32 && return Float64(Base.factorial(Int128(m)))
+    return gamma(Float64(n))
 end
 
 ## from base/math.jl

--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -748,7 +748,7 @@ if Base.MPFR.version() >= v"4.0.0"
     end
 end
 
-const _shifted_gamma_fact_table = [gamma.(collect(1.0:171.0))]
+const _shifted_gamma_fact_table = gamma.(collect(1.0:171.0))
 
 function gamma(n::Union{Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Int128,UInt128})
     if !(0 <= n <= 171) 

--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -750,8 +750,8 @@ end
 
 ## originally from base/combinatorics.jl (and now optimized and changed to handle upcoming change in Julia)
 
-function gamma_new(n::Union{Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Int128,UInt128})
-    1 <= n <= 20 && return Float64(factorial(Int64(n-1)))
+function gamma(n::Union{Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Int128,UInt128})
+    1 <= n <= 21 && return Float64(factorial(Int64(n-1)))
     return gamma(Float64(n))
 end
 


### PR DESCRIPTION
If my https://github.com/JuliaLang/julia/pull/30665 will get pulled this package WILL break, I think.

https://github.com/JuliaMath/SpecialFunctions.jl/blob/9d0caf9833d06fad8df114564f143e7f909b984a/src/gamma.jl#L758

Base._fact_table64 is dangeraous, and as it's a "fact" table, to could alternatively be done here with:

const _fact_table64 = [cumprod(1:Int64(20))]  # as oppoed to what I changed to: const _fact_table64 = [1; cumprod(1:Int64(20))]

Such a change will not automatically benefit from my improved factorial (it seems 22%+ faster), nor would gamma fail if I screwed up...

This change would need to be merged and tagged, right, before my other PR?

Isn't this what you call type piracy ("bad")? And while I could easily have missed this, if I had not known about gamma in Julia 0.5, is there a way of knowing (like searching globally in all Julia packages; at least those in METADATA or the new registry)?