### PR TITLE
fix erf doc

### DIFF
--- a/src/erf.jl
+++ b/src/erf.jl
@@ -47,7 +47,7 @@ end
 Compute the error function of ``x``, defined by
 
 ```math
-\operatorname{erf}(x) = \frac{2}{\pi} \int_0^x \exp(-t^2) \; \mathrm{d}t
+\operatorname{erf}(x) = \frac{2}{\sqrt{\pi}} \int_0^x \exp(-t^2) \; \mathrm{d}t
 \quad \text{for} \quad x \in \mathbb{C} \, .
 ```
 


### PR DESCRIPTION
It seems there is a little typo is the documentation of `erf` : it is said to be defined as 2/pi times the integral of exp(-t^2) between 0 and x. However, a quick numerical check seems to show erf(x) is equal to 2/sqrt(pi) times this integral (which is also the most commonly used definition of erf).