### PR TITLE
update docs for beta_inc, gamma, gamma_inc_inv, zeta, bessels

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,7 +23,7 @@ In this case, the symbols will need to be explicitly imported or called
 with the prefix `SpecialFunctions`.
 This is not necessary for Julia versions 0.6 and later.
 
-On Julia 0.7, [openspecfun](https://github.com/JuliaLang/openspecfun) is not build as
+On Julia 0.7, [openspecfun](https://github.com/JuliaLang/openspecfun) is not built as
 part of Julia.
 Thus for Julia versions 0.7 and later, installing this package downloads openspecfun.
 Binaries of openspecfun are available for macOS, Windows, and Linux (glibc >= 2.6).

--- a/src/bessel.jl
+++ b/src/bessel.jl
@@ -463,7 +463,7 @@ end
 
 Bessel function of the first kind of order `nu`, ``J_\\nu(x)``.
 
-External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_first_kind:_J%CE%B1)
+External links: [DLMF](https://dlmf.nist.gov/10.2.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_first_kind:_J%CE%B1)
 
 See also: [`besseljx(nu,x)`](@ref SpecialFunctions.besseljx), [`besseli(nu,x)`](@ref SpecialFunctions.besseli), [`besselk(nu,x)`](@ref SpecialFunctions.besselk)
 """

--- a/src/bessel.jl
+++ b/src/bessel.jl
@@ -65,6 +65,10 @@ end
     airyai(x)
 
 Airy function of the first kind ``\\operatorname{Ai}(x)``.
+
+See also: [`airyaix`](@ref), [`airyaiprime`](@ref), [`airybi`](@ref)
+
+External links: [DLMF](https://dlmf.nist.gov/9.2), [Wikipedia](https://en.wikipedia.org/wiki/Airy_function)
 """
 function airyai end
 airyai(z::Complex{Float64}) = _airy(z, Int32(0), Int32(1))
@@ -73,6 +77,10 @@ airyai(z::Complex{Float64}) = _airy(z, Int32(0), Int32(1))
     airyaiprime(x)
 
 Derivative of the Airy function of the first kind ``\\operatorname{Ai}'(x)``.
+
+See also: [`airyaiprimex`](@ref), [`airyai`](@ref), [`airybi`](@ref)
+
+External links: [DLMF](https://dlmf.nist.gov/9.2), [Wikipedia](https://en.wikipedia.org/wiki/Airy_function)
 """
 function airyaiprime end
 airyaiprime(z::Complex{Float64}) =  _airy(z, Int32(1), Int32(1))
@@ -81,6 +89,10 @@ airyaiprime(z::Complex{Float64}) =  _airy(z, Int32(1), Int32(1))
     airybi(x)
 
 Airy function of the second kind ``\\operatorname{Bi}(x)``.
+
+See also: [`airybix`](@ref), [`airybiprime`](@ref),  [`airyai`](@ref)
+
+External links: [DLMF](https://dlmf.nist.gov/9.2), [Wikipedia](https://en.wikipedia.org/wiki/Airy_function)
 """
 function airybi end
 airybi(z::Complex{Float64}) = _biry(z, Int32(0), Int32(1))
@@ -89,6 +101,10 @@ airybi(z::Complex{Float64}) = _biry(z, Int32(0), Int32(1))
     airybiprime(x)
 
 Derivative of the Airy function of the second kind ``\\operatorname{Bi}'(x)``.
+
+See also: [`airybiprimex`](@ref), [`airybi`](@ref), [`airyai`](@ref)
+
+External links: [DLMF](https://dlmf.nist.gov/9.2), [Wikipedia](https://en.wikipedia.org/wiki/Airy_function)
 """
 function airybiprime end
 airybiprime(z::Complex{Float64}) = _biry(z, Int32(1), Int32(1))
@@ -98,6 +114,10 @@ airybiprime(z::Complex{Float64}) = _biry(z, Int32(1), Int32(1))
 
 Scaled Airy function of the first kind ``\\operatorname{Ai}(x) e^{\\frac{2}{3} x
 \\sqrt{x}}``.  Throws `DomainError` for negative `Real` arguments.
+
+See also: [`airyai`](@ref), [`airyaiprime`](@ref), [`airybi`](@ref)
+
+External links: [DLMF](https://dlmf.nist.gov/9.2), [Wikipedia](https://en.wikipedia.org/wiki/Airy_function)
 """
 function airyaix end
 airyaix(z::Complex{Float64}) = _airy(z, Int32(0), Int32(2))
@@ -107,6 +127,10 @@ airyaix(z::Complex{Float64}) = _airy(z, Int32(0), Int32(2))
 
 Scaled derivative of the Airy function of the first kind ``\\operatorname{Ai}'(x)
 e^{\\frac{2}{3} x \\sqrt{x}}``.  Throws `DomainError` for negative `Real` arguments.
+
+See also: [`airyaiprime`](@ref), [`airyai`](@ref), [`airybi`](@ref)
+
+External links: [DLMF](https://dlmf.nist.gov/9.2), [Wikipedia](https://en.wikipedia.org/wiki/Airy_function)
 """
 function airyaiprimex end
 airyaiprimex(z::Complex{Float64}) =  _airy(z, Int32(1), Int32(2))
@@ -115,6 +139,10 @@ airyaiprimex(z::Complex{Float64}) =  _airy(z, Int32(1), Int32(2))
     airybix(x)
 
 Scaled Airy function of the second kind ``\\operatorname{Bi}(x) e^{- \\left| \\operatorname{Re} \\left( \\frac{2}{3} x \\sqrt{x} \\right) \\right|}``.
+
+See also: [`airybi`](@ref), [`airybiprime`](@ref), [`airyai`](@ref)
+
+External links: [DLMF](https://dlmf.nist.gov/9.2), [Wikipedia](https://en.wikipedia.org/wiki/Airy_function)
 """
 function airybix end
 airybix(z::Complex{Float64}) = _biry(z, Int32(0), Int32(2))
@@ -123,6 +151,10 @@ airybix(z::Complex{Float64}) = _biry(z, Int32(0), Int32(2))
     airybiprimex(x)
 
 Scaled derivative of the Airy function of the second kind ``\\operatorname{Bi}'(x) e^{- \\left| \\operatorname{Re} \\left( \\frac{2}{3} x \\sqrt{x} \\right) \\right|}``.
+
+See also: [`airybiprime`](@ref), [`airybi`](@ref), [`airyai`](@ref)
+
+External links: [DLMF](https://dlmf.nist.gov/9.2), [Wikipedia](https://en.wikipedia.org/wiki/Airy_function)
 """
 function airybiprimex end
 airybiprimex(z::Complex{Float64}) = _biry(z, Int32(1), Int32(2))
@@ -268,7 +300,7 @@ Bessel function of the third kind of order `nu` (the Hankel function). `k` is ei
 selecting [`hankelh1`](@ref) or [`hankelh2`](@ref), respectively.
 `k` defaults to 1 if it is omitted.
 
-External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Hankel_functions:_H(1)%CE%B1,_H(2)%CE%B1)
 
 See also: [`besselhx`](@ref) for an exponentially scaled variant.
 """
@@ -295,7 +327,7 @@ proportional to ``\\exp(∓iz)/\\sqrt{z}`` for large ``|z|``, and so the
 when `z` has a large imaginary part.  The `besselhx` function cancels this
 exponential factor (analytically), so it avoids these problems.
 
-External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Hankel_functions:_H(1)%CE%B1,_H(2)%CE%B1)
 
 See also: [`besselh`](@ref)
 """
@@ -399,7 +431,7 @@ end
 
 Modified Bessel function of the first kind of order `nu`, ``I_\\nu(x)``.
 
-External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+External links: [DLMF](https://dlmf.nist.gov/10.25), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Modified_Bessel_functions:_I%CE%B1,_K%CE%B1)
 
 See also: [`besselix(nu,x)`](@ref SpecialFunctions.besselix), [`besselj(nu,x)`](@ref SpecialFunctions.besselj), [`besselk(nu,x)`](@ref SpecialFunctions.besselk)
 """
@@ -415,9 +447,9 @@ end
 
 Scaled modified Bessel function of the first kind of order `nu`, ``I_\\nu(x) e^{- | \\operatorname{Re}(x) |}``.
 
-External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+External links: [DLMF](https://dlmf.nist.gov/10.25), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Modified_Bessel_functions:_I%CE%B1,_K%CE%B1)
 
-See also: [`besseli(nu,x)`](@ref SpecialFunctions.besseli)
+See also: [`besseli(nu,x)`](@ref SpecialFunctions.besseli), [`besselj(nu,x)`](@ref SpecialFunctions.besselj), [`besselk(nu,x)`](@ref SpecialFunctions.besselk)
 """
 function besselix(nu::Real, x::AbstractFloat)
     if x < 0 && !isinteger(nu)
@@ -431,7 +463,7 @@ end
 
 Bessel function of the first kind of order `nu`, ``J_\\nu(x)``.
 
-External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_first_kind:_J%CE%B1)
 
 See also: [`besseljx(nu,x)`](@ref SpecialFunctions.besseljx), [`besseli(nu,x)`](@ref SpecialFunctions.besseli), [`besselk(nu,x)`](@ref SpecialFunctions.besselk)
 """
@@ -451,9 +483,9 @@ end
 
 Scaled Bessel function of the first kind of order `nu`, ``J_\\nu(x) e^{- | \\operatorname{Im}(x) |}``.
 
-External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_first_kind:_J%CE%B1)
 
-See also: [`besselj(nu,x)`](@ref SpecialFunctions.besselj)
+See also: [`besselj(nu,x)`](@ref SpecialFunctions.besselj), [`besseli(nu,x)`](@ref SpecialFunctions.besseli), [`besselk(nu,x)`](@ref SpecialFunctions.besselk)
 """
 function besseljx(nu::Real, x::AbstractFloat)
     if x < 0 && !isinteger(nu)
@@ -467,7 +499,7 @@ end
 
 Modified Bessel function of the second kind of order `nu`, ``K_\\nu(x)``.
 
-External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+External links: [DLMF](https://dlmf.nist.gov/10.25), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Modified_Bessel_functions:_I%CE%B1,_K%CE%B1)
 
 See also: See also: [`besselkx(nu,x)`](@ref SpecialFunctions.besselkx), [`besseli(nu,x)`](@ref SpecialFunctions.besseli), [`besselj(nu,x)`](@ref SpecialFunctions.besselj)
 """
@@ -485,9 +517,9 @@ end
 
 Scaled modified Bessel function of the second kind of order `nu`, ``K_\\nu(x) e^x``.
 
-External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+External links: [DLMF](https://dlmf.nist.gov/10.25), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Modified_Bessel_functions:_I%CE%B1,_K%CE%B1)
 
-See also: [`besselk(nu,x)`](@ref SpecialFunctions.besselk)
+See also: [`besselk(nu,x)`](@ref SpecialFunctions.besselk), [`besseli(nu,x)`](@ref SpecialFunctions.besseli), [`besselj(nu,x)`](@ref SpecialFunctions.besselj)
 """
 function besselkx(nu::Real, x::AbstractFloat)
     if x < 0
@@ -503,7 +535,7 @@ end
 
 Bessel function of the second kind of order `nu`, ``Y_\\nu(x)``.
 
-External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_second_kind:_Y%CE%B1)
 
 See also [`besselyx(nu,x)`](@ref SpecialFunctions.besselyx) for a scaled variant.
 """
@@ -522,7 +554,7 @@ end
 Scaled Bessel function of the second kind of order `nu`,
 ``Y_\\nu(x) e^{- | \\operatorname{Im}(x) |}``.
 
-External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_second_kind:_Y%CE%B1)
 
 See also [`bessely(nu,x)`](@ref SpecialFunctions.bessely)
 """
@@ -569,7 +601,7 @@ end
 
 Bessel function of the first kind of order 0, ``J_0(x)``.
 
-External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_first_kind:_J%CE%B1)
 
 See also: [`besselj(nu,x)`](@ref SpecialFunctions.besselj)
 """
@@ -584,7 +616,7 @@ end
 
 Bessel function of the first kind of order 1, ``J_1(x)``.
 
-External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_first_kind:_J%CE%B1)
 
 See also: [`besselj(nu,x)`](@ref SpecialFunctions.besselj)
 """
@@ -605,7 +637,7 @@ end
 
 Bessel function of the second kind of order 0, ``Y_0(x)``.
 
-External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_second_kind:_Y%CE%B1)
 
 See also: [`bessely(nu,x)`](@ref SpecialFunctions.bessely)
 """
@@ -623,7 +655,7 @@ end
 
 Bessel function of the second kind of order 1, ``Y_1(x)``.
 
-External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_second_kind:_Y%CE%B1)
 
 See also: [`bessely(nu,x)`](@ref SpecialFunctions.bessely)
 """
@@ -650,7 +682,7 @@ end
 
 Bessel function of the third kind of order `nu`, ``H^{(1)}_\\nu(x)``.
 
-External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Hankel_functions:_H(1)%CE%B1,_H(2)%CE%B1)
 
 See also: [`hankelh1x`](@ref SpecialFunctions.hankelh1x)
 """
@@ -661,7 +693,7 @@ hankelh1(nu, z) = besselh(nu, 1, z)
 
 Bessel function of the third kind of order `nu`, ``H^{(2)}_\\nu(x)``.
 
-External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Hankel_functions:_H(1)%CE%B1,_H(2)%CE%B1)
 
 See also: [`hankelh2x(nu,x)`](@ref SpecialFunctions.hankelh2x)
 """
@@ -672,7 +704,7 @@ hankelh2(nu, z) = besselh(nu, 2, z)
 
 Scaled Bessel function of the third kind of order `nu`, ``H^{(1)}_\\nu(x) e^{-x i}``.
 
-External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Hankel_functions:_H(1)%CE%B1,_H(2)%CE%B1)
 
 See also: [`hankelh1`](@ref SpecialFunctions.hankelh1)
 """
@@ -683,7 +715,7 @@ hankelh1x(nu, z) = besselhx(nu, 1, z)
 
 Scaled Bessel function of the third kind of order `nu`, ``H^{(2)}_\\nu(x) e^{x i}``.
 
-External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Hankel_functions:_H(1)%CE%B1,_H(2)%CE%B1)
 
 See also: [`hankelh2(nu,x)`](@ref SpecialFunctions.hankelh2)
 """

--- a/src/bessel.jl
+++ b/src/bessel.jl
@@ -300,7 +300,7 @@ Bessel function of the third kind of order `nu` (the Hankel function). `k` is ei
 selecting [`hankelh1`](@ref) or [`hankelh2`](@ref), respectively.
 `k` defaults to 1 if it is omitted.
 
-External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Hankel_functions:_H(1)%CE%B1,_H(2)%CE%B1)
+External links: [DLMF](https://dlmf.nist.gov/10.2.5) and [DLMF](https://dlmf.nist.gov/10.2.6), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Hankel_functions:_H(1)%CE%B1,_H(2)%CE%B1)
 
 See also: [`besselhx`](@ref) for an exponentially scaled variant.
 """

--- a/src/bessel.jl
+++ b/src/bessel.jl
@@ -715,7 +715,7 @@ hankelh1x(nu, z) = besselhx(nu, 1, z)
 
 Scaled Bessel function of the third kind of order `nu`, ``H^{(2)}_\\nu(x) e^{x i}``.
 
-External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Hankel_functions:_H(1)%CE%B1,_H(2)%CE%B1)
+External links: [DLMF](https://dlmf.nist.gov/10.2.6), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Hankel_functions:_H(1)%CE%B1,_H(2)%CE%B1)
 
 See also: [`hankelh2(nu,x)`](@ref SpecialFunctions.hankelh2)
 """

--- a/src/bessel.jl
+++ b/src/bessel.jl
@@ -431,7 +431,7 @@ end
 
 Modified Bessel function of the first kind of order `nu`, ``I_\\nu(x)``.
 
-External links: [DLMF](https://dlmf.nist.gov/10.25), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Modified_Bessel_functions:_I%CE%B1,_K%CE%B1)
+External links: [DLMF](https://dlmf.nist.gov/10.25.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Modified_Bessel_functions:_I%CE%B1,_K%CE%B1)
 
 See also: [`besselix(nu,x)`](@ref SpecialFunctions.besselix), [`besselj(nu,x)`](@ref SpecialFunctions.besselj), [`besselk(nu,x)`](@ref SpecialFunctions.besselk)
 """
@@ -447,7 +447,7 @@ end
 
 Scaled modified Bessel function of the first kind of order `nu`, ``I_\\nu(x) e^{- | \\operatorname{Re}(x) |}``.
 
-External links: [DLMF](https://dlmf.nist.gov/10.25), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Modified_Bessel_functions:_I%CE%B1,_K%CE%B1)
+External links: [DLMF](https://dlmf.nist.gov/10.25.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Modified_Bessel_functions:_I%CE%B1,_K%CE%B1)
 
 See also: [`besseli(nu,x)`](@ref SpecialFunctions.besseli), [`besselj(nu,x)`](@ref SpecialFunctions.besselj), [`besselk(nu,x)`](@ref SpecialFunctions.besselk)
 """
@@ -483,7 +483,7 @@ end
 
 Scaled Bessel function of the first kind of order `nu`, ``J_\\nu(x) e^{- | \\operatorname{Im}(x) |}``.
 
-External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_first_kind:_J%CE%B1)
+External links: [DLMF](https://dlmf.nist.gov/10.2.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_first_kind:_J%CE%B1)
 
 See also: [`besselj(nu,x)`](@ref SpecialFunctions.besselj), [`besseli(nu,x)`](@ref SpecialFunctions.besseli), [`besselk(nu,x)`](@ref SpecialFunctions.besselk)
 """
@@ -499,7 +499,7 @@ end
 
 Modified Bessel function of the second kind of order `nu`, ``K_\\nu(x)``.
 
-External links: [DLMF](https://dlmf.nist.gov/10.25), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Modified_Bessel_functions:_I%CE%B1,_K%CE%B1)
+External links: [DLMF](https://dlmf.nist.gov/10.25.3), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Modified_Bessel_functions:_I%CE%B1,_K%CE%B1)
 
 See also: See also: [`besselkx(nu,x)`](@ref SpecialFunctions.besselkx), [`besseli(nu,x)`](@ref SpecialFunctions.besseli), [`besselj(nu,x)`](@ref SpecialFunctions.besselj)
 """
@@ -517,7 +517,7 @@ end
 
 Scaled modified Bessel function of the second kind of order `nu`, ``K_\\nu(x) e^x``.
 
-External links: [DLMF](https://dlmf.nist.gov/10.25), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Modified_Bessel_functions:_I%CE%B1,_K%CE%B1)
+External links: [DLMF](https://dlmf.nist.gov/10.25.3), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Modified_Bessel_functions:_I%CE%B1,_K%CE%B1)
 
 See also: [`besselk(nu,x)`](@ref SpecialFunctions.besselk), [`besseli(nu,x)`](@ref SpecialFunctions.besseli), [`besselj(nu,x)`](@ref SpecialFunctions.besselj)
 """
@@ -535,7 +535,7 @@ end
 
 Bessel function of the second kind of order `nu`, ``Y_\\nu(x)``.
 
-External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_second_kind:_Y%CE%B1)
+External links: [DLMF](https://dlmf.nist.gov/10.2.3), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_second_kind:_Y%CE%B1)
 
 See also [`besselyx(nu,x)`](@ref SpecialFunctions.besselyx) for a scaled variant.
 """
@@ -637,7 +637,7 @@ end
 
 Bessel function of the second kind of order 0, ``Y_0(x)``.
 
-External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_second_kind:_Y%CE%B1)
+External links: [DLMF](https://dlmf.nist.gov/10.2.3), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_second_kind:_Y%CE%B1)
 
 See also: [`bessely(nu,x)`](@ref SpecialFunctions.bessely)
 """

--- a/src/bessel.jl
+++ b/src/bessel.jl
@@ -601,7 +601,7 @@ end
 
 Bessel function of the first kind of order 0, ``J_0(x)``.
 
-External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_first_kind:_J%CE%B1)
+External links: [DLMF](https://dlmf.nist.gov/10.2.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_first_kind:_J%CE%B1)
 
 See also: [`besselj(nu,x)`](@ref SpecialFunctions.besselj)
 """

--- a/src/bessel.jl
+++ b/src/bessel.jl
@@ -616,7 +616,7 @@ end
 
 Bessel function of the first kind of order 1, ``J_1(x)``.
 
-External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_first_kind:_J%CE%B1)
+External links: [DLMF](https://dlmf.nist.gov/10.2.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_first_kind:_J%CE%B1)
 
 See also: [`besselj(nu,x)`](@ref SpecialFunctions.besselj)
 """

--- a/src/bessel.jl
+++ b/src/bessel.jl
@@ -693,7 +693,7 @@ hankelh1(nu, z) = besselh(nu, 1, z)
 
 Bessel function of the third kind of order `nu`, ``H^{(2)}_\\nu(x)``.
 
-External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Hankel_functions:_H(1)%CE%B1,_H(2)%CE%B1)
+External links: [DLMF](https://dlmf.nist.gov/10.2.6), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Hankel_functions:_H(1)%CE%B1,_H(2)%CE%B1)
 
 See also: [`hankelh2x(nu,x)`](@ref SpecialFunctions.hankelh2x)
 """

--- a/src/bessel.jl
+++ b/src/bessel.jl
@@ -655,7 +655,7 @@ end
 
 Bessel function of the second kind of order 1, ``Y_1(x)``.
 
-External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_second_kind:_Y%CE%B1)
+External links: [DLMF](https://dlmf.nist.gov/10.2.3), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_second_kind:_Y%CE%B1)
 
 See also: [`bessely(nu,x)`](@ref SpecialFunctions.bessely)
 """

--- a/src/bessel.jl
+++ b/src/bessel.jl
@@ -704,7 +704,7 @@ hankelh2(nu, z) = besselh(nu, 2, z)
 
 Scaled Bessel function of the third kind of order `nu`, ``H^{(1)}_\\nu(x) e^{-x i}``.
 
-External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Hankel_functions:_H(1)%CE%B1,_H(2)%CE%B1)
+External links: [DLMF](https://dlmf.nist.gov/10.2.5), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Hankel_functions:_H(1)%CE%B1,_H(2)%CE%B1)
 
 See also: [`hankelh1`](@ref SpecialFunctions.hankelh1)
 """

--- a/src/bessel.jl
+++ b/src/bessel.jl
@@ -554,7 +554,7 @@ end
 Scaled Bessel function of the second kind of order `nu`,
 ``Y_\\nu(x) e^{- | \\operatorname{Im}(x) |}``.
 
-External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_second_kind:_Y%CE%B1)
+External links: [DLMF](https://dlmf.nist.gov/10.2.3), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_second_kind:_Y%CE%B1)
 
 See also [`bessely(nu,x)`](@ref SpecialFunctions.bessely)
 """

--- a/src/bessel.jl
+++ b/src/bessel.jl
@@ -267,7 +267,10 @@ end
 Bessel function of the third kind of order `nu` (the Hankel function). `k` is either 1 or 2,
 selecting [`hankelh1`](@ref) or [`hankelh2`](@ref), respectively.
 `k` defaults to 1 if it is omitted.
-(See also [`besselhx`](@ref) for an exponentially scaled variant.)
+
+External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+
+See also: [`besselhx`](@ref) for an exponentially scaled variant.
 """
 function besselh end
 
@@ -291,6 +294,10 @@ proportional to ``\\exp(∓iz)/\\sqrt{z}`` for large ``|z|``, and so the
 [`besselh`](@ref) function is susceptible to overflow or underflow
 when `z` has a large imaginary part.  The `besselhx` function cancels this
 exponential factor (analytically), so it avoids these problems.
+
+External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+
+See also: [`besselh`](@ref)
 """
 function besselhx end
 
@@ -391,6 +398,10 @@ end
     besseli(nu, x)
 
 Modified Bessel function of the first kind of order `nu`, ``I_\\nu(x)``.
+
+External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+
+See also: [`besselix(nu,x)`](@ref SpecialFunctions.besselix), [`besselj(nu,x)`](@ref SpecialFunctions.besselj), [`besselk(nu,x)`](@ref SpecialFunctions.besselk)
 """
 function besseli(nu::Real, x::AbstractFloat)
     if x < 0 && !isinteger(nu)
@@ -403,6 +414,10 @@ end
     besselix(nu, x)
 
 Scaled modified Bessel function of the first kind of order `nu`, ``I_\\nu(x) e^{- | \\operatorname{Re}(x) |}``.
+
+External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+
+See also: [`besseli(nu,x)`](@ref SpecialFunctions.besseli)
 """
 function besselix(nu::Real, x::AbstractFloat)
     if x < 0 && !isinteger(nu)
@@ -415,6 +430,10 @@ end
     besselj(nu, x)
 
 Bessel function of the first kind of order `nu`, ``J_\\nu(x)``.
+
+External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+
+See also: [`besseljx(nu,x)`](@ref SpecialFunctions.besseljx), [`besseli(nu,x)`](@ref SpecialFunctions.besseli), [`besselk(nu,x)`](@ref SpecialFunctions.besselk)
 """
 function besselj(nu::Real, x::AbstractFloat)
     if isinteger(nu)
@@ -431,6 +450,10 @@ end
     besseljx(nu, x)
 
 Scaled Bessel function of the first kind of order `nu`, ``J_\\nu(x) e^{- | \\operatorname{Im}(x) |}``.
+
+External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+
+See also: [`besselj(nu,x)`](@ref SpecialFunctions.besselj)
 """
 function besseljx(nu::Real, x::AbstractFloat)
     if x < 0 && !isinteger(nu)
@@ -443,6 +466,10 @@ end
     besselk(nu, x)
 
 Modified Bessel function of the second kind of order `nu`, ``K_\\nu(x)``.
+
+External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+
+See also: See also: [`besselkx(nu,x)`](@ref SpecialFunctions.besselkx), [`besseli(nu,x)`](@ref SpecialFunctions.besseli), [`besselj(nu,x)`](@ref SpecialFunctions.besselj)
 """
 function besselk(nu::Real, x::AbstractFloat)
     if x < 0
@@ -457,6 +484,10 @@ end
     besselkx(nu, x)
 
 Scaled modified Bessel function of the second kind of order `nu`, ``K_\\nu(x) e^x``.
+
+External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+
+See also: [`besselk(nu,x)`](@ref SpecialFunctions.besselk)
 """
 function besselkx(nu::Real, x::AbstractFloat)
     if x < 0
@@ -471,6 +502,10 @@ end
     bessely(nu, x)
 
 Bessel function of the second kind of order `nu`, ``Y_\\nu(x)``.
+
+External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+
+See also [`besselyx(nu,x)`](@ref SpecialFunctions.besselyx) for a scaled variant.
 """
 function bessely(nu::Real, x::AbstractFloat)
     if x < 0
@@ -486,6 +521,10 @@ end
 
 Scaled Bessel function of the second kind of order `nu`,
 ``Y_\\nu(x) e^{- | \\operatorname{Im}(x) |}``.
+
+External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+
+See also [`bessely(nu,x)`](@ref SpecialFunctions.bessely)
 """
 function besselyx(nu::Real, x::AbstractFloat)
     if x < 0
@@ -529,6 +568,10 @@ end
     besselj0(x)
 
 Bessel function of the first kind of order 0, ``J_0(x)``.
+
+External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+
+See also: [`besselj(nu,x)`](@ref SpecialFunctions.besselj)
 """
 function besselj0(x::BigFloat)
     z = BigFloat()
@@ -540,6 +583,10 @@ end
     besselj1(x)
 
 Bessel function of the first kind of order 1, ``J_1(x)``.
+
+External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+
+See also: [`besselj(nu,x)`](@ref SpecialFunctions.besselj)
 """
 function besselj1(x::BigFloat)
     z = BigFloat()
@@ -557,6 +604,10 @@ end
     bessely0(x)
 
 Bessel function of the second kind of order 0, ``Y_0(x)``.
+
+External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+
+See also: [`bessely(nu,x)`](@ref SpecialFunctions.bessely)
 """
 function bessely0(x::BigFloat)
     if x < 0
@@ -571,6 +622,10 @@ end
     bessely1(x)
 
 Bessel function of the second kind of order 1, ``Y_1(x)``.
+
+External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+
+See also: [`bessely(nu,x)`](@ref SpecialFunctions.bessely)
 """
 function bessely1(x::BigFloat)
     if x < 0
@@ -594,6 +649,10 @@ end
     hankelh1(nu, x)
 
 Bessel function of the third kind of order `nu`, ``H^{(1)}_\\nu(x)``.
+
+External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+
+See also: [`hankelh1x`](@ref SpecialFunctions.hankelh1x)
 """
 hankelh1(nu, z) = besselh(nu, 1, z)
 
@@ -601,6 +660,10 @@ hankelh1(nu, z) = besselh(nu, 1, z)
     hankelh2(nu, x)
 
 Bessel function of the third kind of order `nu`, ``H^{(2)}_\\nu(x)``.
+
+External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+
+See also: [`hankelh2x(nu,x)`](@ref SpecialFunctions.hankelh2x)
 """
 hankelh2(nu, z) = besselh(nu, 2, z)
 
@@ -608,6 +671,10 @@ hankelh2(nu, z) = besselh(nu, 2, z)
     hankelh1x(nu, x)
 
 Scaled Bessel function of the third kind of order `nu`, ``H^{(1)}_\\nu(x) e^{-x i}``.
+
+External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+
+See also: [`hankelh1`](@ref SpecialFunctions.hankelh1)
 """
 hankelh1x(nu, z) = besselhx(nu, 1, z)
 
@@ -615,5 +682,9 @@ hankelh1x(nu, z) = besselhx(nu, 1, z)
     hankelh2x(nu, x)
 
 Scaled Bessel function of the third kind of order `nu`, ``H^{(2)}_\\nu(x) e^{x i}``.
+
+External links: [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function)
+
+See also: [`hankelh2(nu,x)`](@ref SpecialFunctions.hankelh2)
 """
 hankelh2x(nu, z) = besselhx(nu, 2, z)

--- a/src/bessel.jl
+++ b/src/bessel.jl
@@ -682,7 +682,7 @@ end
 
 Bessel function of the third kind of order `nu`, ``H^{(1)}_\\nu(x)``.
 
-External links: [DLMF](https://dlmf.nist.gov/10.2), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Hankel_functions:_H(1)%CE%B1,_H(2)%CE%B1)
+External links: [DLMF](https://dlmf.nist.gov/10.2.5), [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Hankel_functions:_H(1)%CE%B1,_H(2)%CE%B1)
 
 See also: [`hankelh1x`](@ref SpecialFunctions.hankelh1x)
 """

--- a/src/beta_inc.jl
+++ b/src/beta_inc.jl
@@ -179,8 +179,8 @@ External links: [DLMF](https://dlmf.nist.gov/8.17#E22), [Wikipedia](https://en.w
 
 See also: [`beta_inc`](@ref)
 
-# Implemented by
-'BFRAC(A,B,X,Y,LAMBDA,EPS) from Didonato and Morris (1982)'
+# Implementation
+`BFRAC(A,B,X,Y,LAMBDA,EPS)` from Didonato and Morris (1982)
 """
 function beta_inc_cont_fraction(a::Float64, b::Float64, x::Float64, y::Float64, lambda::Float64, epps::Float64)
     ans = beta_integrand(a,b,x,y)
@@ -245,8 +245,8 @@ External links: [DLMF](https://dlmf.nist.gov/8.17#E22), [Wikipedia](https://en.w
 
 See also: [`beta_inc`](@ref)
 
-# Implemented by
-'BASYM(A,B,LAMBDA,EPS) from Didonato and Morris (1982)''
+# Implemention
+`BASYM(A,B,LAMBDA,EPS)` from Didonato and Morris (1982)
 """
 function beta_inc_asymptotic_symmetric(a::Float64, b::Float64, lambda::Float64, epps::Float64)
     a0 =zeros(22)
@@ -417,8 +417,8 @@ External links: [DLMF](https://dlmf.nist.gov/8.17#E22), [Wikipedia](https://en.w
 
 See also: [`beta_inc`](@ref)
 
-# Implemented by
-'FPSER(A,B,X,EPS) from Didonato and Morris (1982)''
+# Implementation
+`FPSER(A,B,X,EPS)` from Didonato and Morris (1982)
 """
 function beta_inc_power_series2(a::Float64, b::Float64, x::Float64, epps::Float64)
     ans = 1.0
@@ -459,8 +459,8 @@ External links: [DLMF](https://dlmf.nist.gov/8.17#E22), [Wikipedia](https://en.w
 
 See also: [`beta_inc`](@ref)
 
-# Implemented by
-'APSER(A,B,X,EPS) from Didonato and Morris (1982)'
+# Implementation
+`APSER(A,B,X,EPS)` from Didonato and Morris (1982)
 """
 function beta_inc_power_series1(a::Float64, b::Float64, x::Float64, epps::Float64)
     g = Base.MathConstants.eulergamma
@@ -499,8 +499,8 @@ External links: [DLMF](https://dlmf.nist.gov/8.17#E22), [Wikipedia](https://en.w
 
 See also: [`beta_inc`](@ref)
 
-# Implemented by
-'BPSER(A,B,X,EPS) from Didonato and Morris (1982)'
+# Implementation
+`BPSER(A,B,X,EPS)` from Didonato and Morris (1982)
 """
 function beta_inc_power_series(a::Float64, b::Float64, x::Float64, epps::Float64)
     ans = 0.0

--- a/src/beta_inc.jl
+++ b/src/beta_inc.jl
@@ -664,6 +664,8 @@ I_{x}(a,b) = \\frac{1}{B(a,b)} \\int_{0}^{x} t^{a-1}(1-t)^{b-1} dt,
 where ``B(a,b) = \\Gamma(a)\\Gamma(b)/\\Gamma(a+b)``.
 
 External links: [DLMF](https://dlmf.nist.gov/8.17#E1), [Wikipedia](https://en.wikipedia.org/wiki/Beta_function#Incomplete_beta_function)
+
+See also: [`beta_inc_inv(a,b,p,q)`](@ref SpecialFunctions.beta_inc_inv)
 """
 function beta_inc(a::Float64, b::Float64, x::Float64, y::Float64)
     p = 0.0
@@ -835,7 +837,7 @@ beta_inc(a::T, b::T, x::T, y::T) where {T<:AbstractFloat} = throw(MethodError(be
 
 Computes inverse of incomplete beta function. Given `a`,`b` and ``I_{x}(a,b) = p`` find `x` and return tuple (x,y).
 
-See also: [`beta_inc(a,b,x,y)`](@ref SpecialFunctions.beta_inc)
+See also: [`beta_inc(a,b,x)`](@ref SpecialFunctions.beta_inc)
 """
 function beta_inc_inv(a::Float64, b::Float64, p::Float64, q::Float64; lb = logbeta(a,b)[1])
     fpu = 1e-30

--- a/src/beta_inc.jl
+++ b/src/beta_inc.jl
@@ -172,10 +172,15 @@ end
 """
     beta_inc_cont_fraction(a,b,x,y,lambda,epps)
 
-Compute ``I_{x}(a,b)`` using continued fraction expansion when a,b > 1.
+Compute ``I_{x}(a,b)`` using continued fraction expansion when `a,b > 1`.
 It is assumed that ``\\lambda = (a+b)*y - b``
-DLMF : https://dlmf.nist.gov/8.17#E22
-BFRAC(A,B,X,Y,LAMBDA,EPS) from Didonato and Morris (1982)
+
+External links: [DLMF](https://dlmf.nist.gov/8.17#E22), [Wikipedia](https://en.wikipedia.org/wiki/Beta_function#Incomplete_beta_function)
+
+See also: [`beta_inc`](@ref)
+
+# Implemented by
+'BFRAC(A,B,X,Y,LAMBDA,EPS) from Didonato and Morris (1982)'
 """
 function beta_inc_cont_fraction(a::Float64, b::Float64, x::Float64, y::Float64, lambda::Float64, epps::Float64)
     ans = beta_integrand(a,b,x,y)
@@ -233,9 +238,15 @@ end
 """
     beta_inc_asymptotic_symmetric(a,b,lambda,epps)
 
-Compute ``I_{x}(a,b)`` using asymptotic expansion for a,b >= 15.
-It is assumed that ``\\lambda = (a+b)*y - b``
-BASYM(A,B,LAMBDA,EPS) from Didonato and Morris (1982)
+Compute ``I_{x}(a,b)`` using asymptotic expansion for `a,b >= 15`.
+It is assumed that ``\\lambda = (a+b)*y - b``.
+
+External links: [DLMF](https://dlmf.nist.gov/8.17#E22), [Wikipedia](https://en.wikipedia.org/wiki/Beta_function#Incomplete_beta_function)
+
+See also: [`beta_inc`](@ref)
+
+# Implemented by
+'BASYM(A,B,LAMBDA,EPS) from Didonato and Morris (1982)''
 """
 function beta_inc_asymptotic_symmetric(a::Float64, b::Float64, lambda::Float64, epps::Float64)
     a0 =zeros(22)
@@ -326,8 +337,12 @@ end
 """
     beta_inc_asymptotic_asymmetric(a,b,x,y,w,epps)
 
-Evaluation of I_{x}(a,b) when b < min(epps,epps*a) and x <= 0.5 using asymptotic expansion.
-It is assumed a >= 15 and b <= 1, and epps is tolerance used.
+Evaluation of ``I_{x}(a,b)`` when `b < min(epps,epps*a)` and `x <= 0.5` using asymptotic expansion.
+It is assumed `a >= 15` and `b <= 1`, and epps is tolerance used.
+
+External links: [DLMF](https://dlmf.nist.gov/8.17#E22), [Wikipedia](https://en.wikipedia.org/wiki/Beta_function#Incomplete_beta_function)
+
+See also: [`beta_inc`](@ref)
 """
 function beta_inc_asymptotic_asymmetric(a::Float64, b::Float64, x::Float64, y::Float64, w::Float64, epps::Float64)
     c = zeros(31)
@@ -396,8 +411,14 @@ end
 """
     beta_inc_power_series2(a,b,x,epps)
 
-Variant of BPSER(A,B,X,EPS).
-FPSER(A,B,X,EPS) from Didonato and Morris (1982)
+Variant of `BPSER(A,B,X,EPS)`.
+
+External links: [DLMF](https://dlmf.nist.gov/8.17#E22), [Wikipedia](https://en.wikipedia.org/wiki/Beta_function#Incomplete_beta_function)
+
+See also: [`beta_inc`](@ref)
+
+# Implemented by
+'FPSER(A,B,X,EPS) from Didonato and Morris (1982)''
 """
 function beta_inc_power_series2(a::Float64, b::Float64, x::Float64, epps::Float64)
     ans = 1.0
@@ -432,8 +453,14 @@ end
 """
     beta_inc_power_series1(a,b,x,epps)
 
-Another variant of BPSER(A,B,X,EPS)
-APSER(A,B,X,EPS) from Didonato and Morris (1982)
+Another variant of `BPSER(A,B,X,EPS)`.
+
+External links: [DLMF](https://dlmf.nist.gov/8.17#E22), [Wikipedia](https://en.wikipedia.org/wiki/Beta_function#Incomplete_beta_function)
+
+See also: [`beta_inc`](@ref)
+
+# Implemented by
+'APSER(A,B,X,EPS) from Didonato and Morris (1982)'
 """
 function beta_inc_power_series1(a::Float64, b::Float64, x::Float64, epps::Float64)
     g = Base.MathConstants.eulergamma
@@ -464,11 +491,16 @@ end
 """
     beta_inc_power_series(a,b,x,epps)
 
-Computes Ix(a,b) using power series :
+Computes ``I_x(a,b)`` using power series :
 ```math
-I_{x}(a,b) = G(a,b)x^{a}/a (1 + a\\sum_{1}^{\\infty}((1-b)(2-b)...(j-b)/j!(a+j)) x^{j})
+I_{x}(a,b) = G(a,b)x^{a}/a (1 + a\\sum_{j=1}^{\\infty}((1-b)(2-b)...(j-b)/j!(a+j)) x^{j})
 ```
-BPSER(A,B,X,EPS) from Didonato and Morris (1982)
+External links: [DLMF](https://dlmf.nist.gov/8.17#E22), [Wikipedia](https://en.wikipedia.org/wiki/Beta_function#Incomplete_beta_function)
+
+See also: [`beta_inc`](@ref)
+
+# Implemented by
+'BPSER(A,B,X,EPS) from Didonato and Morris (1982)'
 """
 function beta_inc_power_series(a::Float64, b::Float64, x::Float64, epps::Float64)
     ans = 0.0
@@ -559,8 +591,12 @@ end
 """
     beta_inc_diff(a,b,x,y,n,epps)
 
-Compute ``I_{x}(a,b) - I_{x}(a+n,b)`` where n is positive integer and epps is tolerance.
-A more generalised version of https://dlmf.nist.gov/8.17#E20
+Compute ``I_{x}(a,b) - I_{x}(a+n,b)`` where `n` is positive integer and epps is tolerance.
+A generalised version of [DLMF](https://dlmf.nist.gov/8.17#E20).
+
+External links: [DLMF](https://dlmf.nist.gov/8.17#E20), [Wikipedia](https://en.wikipedia.org/wiki/Beta_function#Incomplete_beta_function)
+
+See also: [`beta_inc`](@ref)
 """
 function beta_inc_diff(a::Float64, b::Float64, x::Float64, y::Float64, n::Integer, epps::Float64)
     apb = a + b
@@ -835,7 +871,7 @@ beta_inc(a::T, b::T, x::T, y::T) where {T<:AbstractFloat} = throw(MethodError(be
 """
     beta_inc_inv(a,b,p,q,lb=logbeta(a,b)[1])
 
-Computes inverse of incomplete beta function. Given `a`,`b` and ``I_{x}(a,b) = p`` find `x` and return tuple (x,y).
+Computes inverse of incomplete beta function. Given `a`,`b` and ``I_{x}(a,b) = p`` find `x` and return tuple `(x,y)`.
 
 See also: [`beta_inc(a,b,x)`](@ref SpecialFunctions.beta_inc)
 """

--- a/src/beta_inc.jl
+++ b/src/beta_inc.jl
@@ -655,15 +655,15 @@ end
 #Wikipedia : https://en.wikipedia.org/wiki/Beta_function#Incomplete_beta_function
 
 """
-    beta_inc(a,b,x,y)
+    beta_inc(a,b,x)
 
-Computes Incomplete Beta Function Ratios given by:
+Returns a tuple ``(I_{x}(a,b),1.0-I_{x}(a,b))`` where the Regularized Incomplete Beta Function is given by:
 ```math
-I_{x}(a,b) = G(a,b) \\int_{0}^{x} t^{a-1}(1-t)^{b-1} dt,
+I_{x}(a,b) = \\frac{1}{B(a,b)} \\int_{0}^{x} t^{a-1}(1-t)^{b-1} dt,
 ```
-and ``I_{y}(a,b) = 1.0 - I_{x}(a,b)``.
-given
-``B(a,b) = 1/G(a,b) = \\Gamma(a)\\Gamma(b)/\\Gamma(a+b)`` and ``x+y = 1``.
+where ``B(a,b) = \\Gamma(a)\\Gamma(b)/\\Gamma(a+b)``.
+
+External links: [DLMF](https://dlmf.nist.gov/8.17#E1), [Wikipedia](https://en.wikipedia.org/wiki/Beta_function#Incomplete_beta_function)
 """
 function beta_inc(a::Float64, b::Float64, x::Float64, y::Float64)
     p = 0.0
@@ -834,6 +834,8 @@ beta_inc(a::T, b::T, x::T, y::T) where {T<:AbstractFloat} = throw(MethodError(be
     beta_inc_inv(a,b,p,q,lb=logbeta(a,b)[1])
 
 Computes inverse of incomplete beta function. Given `a`,`b` and ``I_{x}(a,b) = p`` find `x` and return tuple (x,y).
+
+See also: [`beta_inc(a,b,x,y)`](@ref SpecialFunctions.beta_inc)
 """
 function beta_inc_inv(a::Float64, b::Float64, p::Float64, q::Float64; lb = logbeta(a,b)[1])
     fpu = 1e-30

--- a/src/betanc.jl
+++ b/src/betanc.jl
@@ -147,8 +147,8 @@ Compute the CDF of the noncentral beta distribution given by
 ```math
 I_{x}(a,b;\\lambda ) = \\sum_{j=0}^{\\infty}q(\\lambda/2,j)I_{x}(a+j,b;0)
 ```
-For lambda < 54 : algorithm suggested by Lenth(1987) in ncbeta_tail(a,b,lambda,x).
-Else for lambda >= 54 : modification in Chattamvelli(1997) in ncbeta_poisson(a,b,lambda,x) by using both forward and backward recurrences.
+For ``\\lambda < 54`` : algorithm suggested by Lenth(1987) in `ncbeta_tail(a,b,lambda,x)`.
+Else for ``\\lambda >= 54`` : modification in Chattamvelli(1997) in `ncbeta_poisson(a,b,lambda,x)` by using both forward and backward recurrences.
 """
 function ncbeta(a::Float64, b::Float64, lambda::Float64, x::Float64)
     ans = x

--- a/src/erf.jl
+++ b/src/erf.jl
@@ -439,8 +439,7 @@ Compute the natural logarithm of the complementary error function of ``x``, that
 
 This is the accurate version of ``\operatorname{ln}(\operatorname{erfc}(x))`` for large ``x``.
 
-External links:
-[Wikipedia](https://en.wikipedia.org/wiki/Error_function).
+External links: [Wikipedia](https://en.wikipedia.org/wiki/Error_function).
 
 See also: [`erfcx(x)`](@ref SpecialFunctions.erfcx).
 

--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -210,12 +210,17 @@ end
 """
     zeta(s, z)
 
-Generalized zeta function ``\\zeta(s, z)``, defined
-by the sum ``\\sum_{k=0}^\\infty ((k+z)^2)^{-s/2}``, where
-any term with ``k+z=0`` is excluded.  For ``\\Re z > 0``,
+Generalized zeta function defined by
+```math
+\\zeta(s, z)=\\sum_{k=0}^\\infty \\frac{1}{((k+z)^2)^{s/2}},
+```
+where any term with ``k+z=0`` is excluded.  For ``\\Re z > 0``,
 this definition is equivalent to the Hurwitz zeta function
-``\\sum_{k=0}^\\infty (k+z)^{-s}``.   For ``z=1``, it yields
-the Riemann zeta function ``\\zeta(s)``.
+``\\sum_{k=0}^\\infty (k+z)^{-s}``.
+
+The Riemann zeta function is recovered as ``\\zeta(s)=\\zeta(s,1)``.
+
+External links: [Riemann zeta function](https://en.wikipedia.org/wiki/Riemann_zeta_function), [Hurwitz zeta function](https://en.wikipedia.org/wiki/Hurwitz_zeta_function)
 """
 function zeta(s::ComplexOrReal{Float64}, z::ComplexOrReal{Float64})
     ζ = zero(promote_type(typeof(s), typeof(z)))
@@ -322,6 +327,10 @@ end
 
 Compute the polygamma function of order `m` of argument `x` (the `(m+1)`th derivative of the
 logarithm of `gamma(x)`)
+
+External links: [Wikipedia](https://en.wikipedia.org/wiki/Polygamma_function)
+
+See also: [`gamma(z)`](@ref SpecialFunctions.gamma)
 """
 function polygamma(m::Integer, z::ComplexOrReal{Float64})
     m == 0 && return digamma(z)
@@ -385,7 +394,13 @@ end
 """
     zeta(s)
 
-Riemann zeta function ``\\zeta(s)``.
+Riemann zeta function
+
+```math
+\\zeta(s)=\\sum_{n=1}^\\infty \\frac{1}{n^s}\\quad\\text{for}\\quad s\\in\\mathbb{C}.
+```
+
+External links: [Wikipedia](https://en.wikipedia.org/wiki/Riemann_zeta_function)
 """
 function zeta(s::ComplexOrReal{Float64})
     # Riemann zeta function; algorithm is based on specializing the Hurwitz

--- a/src/gamma_inc.jl
+++ b/src/gamma_inc.jl
@@ -827,7 +827,7 @@ Q(x,a)=\\frac{1}{\\Gamma (a)} \\int_{x}^{\\infty} e^{-t}t^{a-1} dt.
 
 `IND ∈ [0,1,2]` sets accuracy: `IND=0` means 14 significant digits accuracy, `IND=1` means 6 significant digit, and `IND=2` means only 3 digit accuracy.
 
-External links: [DLMF](https://dlmf.nist.gov/8.2#E4), [NIST](https://dlmf.nist.gov/8.2#E5), [Wikipedia](https://en.wikipedia.org/wiki/Incomplete_gamma_function)
+External links: [DLMF](https://dlmf.nist.gov/8.2#E4), [Wikipedia](https://en.wikipedia.org/wiki/Incomplete_gamma_function)
 
 See also [`gamma(z)`](@ref SpecialFunctions.gamma), [`gamma_inc_inv(a,p,q)`](@ref SpecialFunctions.gamma_inc_inv)
 """
@@ -949,8 +949,7 @@ gamma_inc(a::AbstractFloat,x::AbstractFloat,ind::Integer) = throw(MethodError(ga
 
 Inverts the `gamma_inc(a,x)` function, by computing `x` given `a`,`p`,`q` in ``P(a,x)=p`` and ``Q(a,x)=q``.
 
-External links: [DLMF](https://dlmf.nist.gov/8.2#E4), [NIST](https://dlmf.nist.gov/8.2#E5),
-[Wikipedia](https://en.wikipedia.org/wiki/Incomplete_gamma_function)
+External links: [DLMF](https://dlmf.nist.gov/8.2#E4), [Wikipedia](https://en.wikipedia.org/wiki/Incomplete_gamma_function)
 
 See also: [`gamma_inc(a,x,ind)`](@ref SpecialFunctions.gamma_inc).
 """

--- a/src/gamma_inc.jl
+++ b/src/gamma_inc.jl
@@ -347,12 +347,15 @@ end
 """
     gamma_inc_cf(a, x, ind)
 
-Computes P(a,x) by continued fraction expansion given by :
+Computes ``P(a,x)`` by continued fraction expansion given by :
 ```math
 R(a,x) * \\frac{1}{1-\\frac{z}{a+1+\\frac{z}{a+2-\\frac{(a+1)z}{a+3+\\frac{2z}{a+4-\\frac{(a+2)z}{a+5+\\frac{3z}{a+6-\\dots}}}}}}}
 ```
-Used when 1 <= a <= BIG and x < x0.
-DLMF : https://dlmf.nist.gov/8.9#E2
+Used when `1 <= a <= BIG` and `x < x0`.
+
+External links: [DLMF](https://dlmf.nist.gov/8.9#E2)
+
+See also: [`gamma_inc(a,x,ind)`](@ref SpecialFunctions.gamma_inc)
 """
 function gamma_inc_cf(a::Float64, x::Float64, ind::Integer)
     acc = acc0[ind + 1]
@@ -786,7 +789,7 @@ end
 Compute `x0` - initial approximation when `a` is large.
 The inversion problem is rewritten as :
 ```math
-0.5 \\text{erfc}(\\eta \\sqrt{a/2}) + R_{a}(\\eta) = q
+0.5 \\operatorname{erfc}(\\eta \\sqrt{a/2}) + R_{a}(\\eta) = q
 ```
 For large values of `a` we can write: ``\\eta(q,a) = \\eta_{0}(q,a) + \\epsilon(\\eta_{0},a)``
 and it is possible to expand:
@@ -947,7 +950,7 @@ gamma_inc(a::AbstractFloat,x::AbstractFloat,ind::Integer) = throw(MethodError(ga
 Inverts the `gamma_inc(a,x)` function, by computing `x` given `a`,`p`,`q` in ``P(a,x)=p`` and ``Q(a,x)=q``.
 
 External links: [DLMF](https://dlmf.nist.gov/8.2#E4), [NIST](https://dlmf.nist.gov/8.2#E5),
-Wikipedia](https://en.wikipedia.org/wiki/Incomplete_gamma_function)
+[Wikipedia](https://en.wikipedia.org/wiki/Incomplete_gamma_function)
 
 See also: [`gamma_inc(a,x,ind)`](@ref SpecialFunctions.gamma_inc).
 """

--- a/src/gamma_inc.jl
+++ b/src/gamma_inc.jl
@@ -93,8 +93,8 @@ end
 """
    rgamma1pm1(a)
 
-   Computation of 1/Gamma(a+1) - 1 for -0.5<=a<=1.5 : ``1/\\Gamma (a+1) - 1``
-   Uses the relation gamma(a+1) = a*gamma(a)
+   Computation of ``1/Gamma(a+1) - 1`` for `-0.5<=a<=1.5` : ``1/\\Gamma (a+1) - 1``
+   Uses the relation `gamma(a+1) = a*gamma(a)`.
 """
 function rgamma1pm1(a::Float64)
     t=a
@@ -117,7 +117,7 @@ end
 """
     rgammax(a,x)
 
-Evaluation of exp(-x)*x^a/gamma(a) : ``1/\\Gamma(a) e^{-x} x^{a}``
+Evaluation of ``1/\\Gamma(a) e^{-x} x^{a}``.
 """
 function rgammax(a::Float64,x::Float64)
     if x == 0.0
@@ -147,7 +147,7 @@ end
 """
     auxgam(x)
 
-Compute function `g` in ``1/\\Gamma(x+1) = 1+x*(x-1)*g(x)``, -1 <= x <= 1
+Compute function `g` in ``1/\\Gamma(x+1) = 1+x*(x-1)*g(x)``, `-1 <= x <= 1`.
 """
 function auxgam(x::Float64)
     if x < 0
@@ -157,10 +157,11 @@ function auxgam(x::Float64)
         return chepolsum(t, auxgam_coef)
     end
 end
+
 """
     loggamma1p(a)
 
-Compute ``log(\\Gamma(1+a))`` for -1 < a <= 1.
+Compute ``log(\\Gamma(1+a))`` for `-1 < a <= 1`.
 """
 function loggamma1p(x::Float64)
     return -log1p(x*(x-1.0)*auxgam(x))
@@ -169,7 +170,7 @@ end
 """
     chepolsum(n,x,a)
 
-Computes a series of Chebyshev Polynomials given by : a[1]/2 + a[2]T1(x) + .... + a[n]T{n-1}(X)
+Computes a series of Chebyshev Polynomials given by: `a[1]/2 + a[2]T1(x) + .... + a[n]T{n-1}(X)`.
 """
 function chepolsum(x::Float64, a::Array{Float64,1})
     n = length(a)
@@ -189,6 +190,7 @@ function chepolsum(x::Float64, a::Array{Float64,1})
         return a[1]/2.0 - r + h*x
     end
 end
+
 """
     stirling(x)
 
@@ -216,11 +218,14 @@ function stirling(x::Float64)
         end
     end
 end
-"""
+@doc raw"""
     gammax(x)
 
-`gammax(x)` = ``e^{stirling(x)}`` if `x>0`,
-else ``\\Gamma(x)/(e^{-x + (x-0.5)*log(x)}/\\sqrt{2 \\pi}``.
+```math
+\operatorname{gammax}(x) = \begin{cases}e^{\operatorname{stirling}(x)}\quad\quad\quad \text{if} \quad x>0,\\
+\frac{\Gamma(x)}{\sqrt{2 \pi}e^{-x + (x-0.5)\operatorname{log}(x)}},\quad \text{if} \quad x\leq 0.
+\end{cases}
+```
 """
 function gammax(x::Float64)
     if x >= 3
@@ -234,7 +239,7 @@ end
 """
     lambdaeta(eta)
 
-Function to compute the value of eta satisfying ``eta^{2}/2 = \\lambda-1-\\ln{\\lambda}``
+Compute the value of eta satisfying ``eta^{2}/2 = \\lambda-1-\\ln{\\lambda}``.
 """
 function lambdaeta(eta::Float64)
     s = eta*eta*0.5

--- a/src/sincosint.jl
+++ b/src/sincosint.jl
@@ -251,7 +251,7 @@ Using the rational approximants tabulated in:
 > <http://dx.doi.org/10.1007/BF02142806>,
 > <https://link.springer.com/article/10.1007/BF02142806>.
 
-Note: the second zero of ``Ci(x)`` has a typo that is fixed:
+Note: the second zero of ``\operatorname{Ci}(x)`` has a typo that is fixed:
 ``r_1 = 3.38418 0422\mathbf{8} 51186 42639 78511 46402`` in the article, but is in fact:
 ``r_1 = 3.38418 0422\mathbf{5} 51186 42639 78511 46402``.
 """
@@ -283,7 +283,7 @@ Using the rational approximants tabulated in:
 > <http://dx.doi.org/10.1007/BF02142806>,
 > <https://link.springer.com/article/10.1007/BF02142806>.
 
-Note: the second zero of ``Ci(x)`` has a typo that is fixed:
+Note: the second zero of ``\operatorname{Ci}(x)`` has a typo that is fixed:
 ``r_1 = 3.38418 0422\mathbf{8} 51186 42639 78511 46402`` in the article, but is in fact:
 ``r_1 = 3.38418 0422\mathbf{5} 51186 42639 78511 46402``.
 """

--- a/src/sincosint.jl
+++ b/src/sincosint.jl
@@ -251,7 +251,7 @@ Using the rational approximants tabulated in:
 > <http://dx.doi.org/10.1007/BF02142806>,
 > <https://link.springer.com/article/10.1007/BF02142806>.
 
-Note: the second zero of ``\operatorname{Ci}(x)`` has a typo that is fixed:
+Note: the second zero of ``\text{Ci}(x)`` has a typo that is fixed:
 ``r_1 = 3.38418 0422\mathbf{8} 51186 42639 78511 46402`` in the article, but is in fact:
 ``r_1 = 3.38418 0422\mathbf{5} 51186 42639 78511 46402``.
 """
@@ -283,7 +283,7 @@ Using the rational approximants tabulated in:
 > <http://dx.doi.org/10.1007/BF02142806>,
 > <https://link.springer.com/article/10.1007/BF02142806>.
 
-Note: the second zero of ``\operatorname{Ci}(x)`` has a typo that is fixed:
+Note: the second zero of ``\text{Ci}(x)`` has a typo that is fixed:
 ``r_1 = 3.38418 0422\mathbf{8} 51186 42639 78511 46402`` in the article, but is in fact:
 ``r_1 = 3.38418 0422\mathbf{5} 51186 42639 78511 46402``.
 """


### PR DESCRIPTION
This PR only changes docstrings. Have added `See also` and `External links` where I can see an obvious way to do it.

- `beta_inc`: changed function signature to `beta_inc(a,b,x)`, and made explanation consistent. This is simpler to explain and call since `y=1-x`, is enforced in the `beta_inc(a,b,x,y)` form anyway.  
- Tidy ups in `gamma`, `gamma_inc`, `gamm_inc_inv`, `zeta`. 
- bessel functions: cross and external links