### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/src/erf.jl
+++ b/src/erf.jl
@@ -184,7 +184,7 @@ Using the rational approximants tabulated in:
 > J. M. Blair, C. A. Edwards, and J. H. Johnson,
 > "Rational Chebyshev approximations for the inverse of the error function",
 > Math. Comp. 30, pp. 827--830 (1976).
-> <http://dx.doi.org/10.1090/S0025-5718-1976-0421040-7>,
+> <https://doi.org/10.1090/S0025-5718-1976-0421040-7>,
 > <http://www.jstor.org/stable/2005402>
 """
 function erfinv(x::Float64)
@@ -320,7 +320,7 @@ Using the rational approximants tabulated in:
 > J. M. Blair, C. A. Edwards, and J. H. Johnson,
 > "Rational Chebyshev approximations for the inverse of the error function",
 > Math. Comp. 30, pp. 827--830 (1976).
-> <http://dx.doi.org/10.1090/S0025-5718-1976-0421040-7>,
+> <https://doi.org/10.1090/S0025-5718-1976-0421040-7>,
 > <http://www.jstor.org/stable/2005402>
 """
 function erfcinv(y::Float64)

--- a/src/sincosint.jl
+++ b/src/sincosint.jl
@@ -248,7 +248,7 @@ Using the rational approximants tabulated in:
 > A.J. MacLeod,
 > "Rational approximations, software and test methods for sine and cosine integrals",
 > Numer. Algor. 12, pp. 259--272 (1996).
-> <http://dx.doi.org/10.1007/BF02142806>,
+> <https://doi.org/10.1007/BF02142806>,
 > <https://link.springer.com/article/10.1007/BF02142806>.
 
 Note: the second zero of ``\text{Ci}(x)`` has a typo that is fixed:
@@ -280,7 +280,7 @@ Using the rational approximants tabulated in:
 > A.J. MacLeod,
 > "Rational approximations, software and test methods for sine and cosine integrals",
 > Numer. Algor. 12, pp. 259--272 (1996).
-> <http://dx.doi.org/10.1007/BF02142806>,
+> <https://doi.org/10.1007/BF02142806>,
 > <https://link.springer.com/article/10.1007/BF02142806>.
 
 Note: the second zero of ``\text{Ci}(x)`` has a typo that is fixed:


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!