### PR TITLE
a little ordering

### DIFF
--- a/src/SpecialFunctions.jl
+++ b/src/SpecialFunctions.jl
@@ -56,6 +56,7 @@ export
     cosint,
     lbinomial
 
+include("prelude.jl")
 include("bessel.jl")
 include("erf.jl")
 include("ellip.jl")

--- a/src/bessel.jl
+++ b/src/bessel.jl
@@ -1,7 +1,5 @@
 # This file contains code that was formerly a part of Julia. License is MIT: http://julialang.org/license
 
-using Base.Math: nan_dom_err
-
 struct AmosException <: Exception
     id::Int32
 end

--- a/src/beta_inc.jl
+++ b/src/beta_inc.jl
@@ -46,9 +46,7 @@ Compute stirling(a0) + stirling(b0) - stirling(a0 + b0)
 for a0,b0 >= 8
 """
 function stirling_corr(a0::Float64, b0::Float64)
-    a = min(a0,b0)
-    b = max(a0,b0)
-
+    a,b = minmax(a0,b0)
     h = a/b
     c = h/(1.0 + h)
     x = 1.0/(1.0 + h)

--- a/src/beta_inc.jl
+++ b/src/beta_inc.jl
@@ -1,5 +1,4 @@
-using Base.Math: @horner
-using Base.MPFR: ROUNDING_MODE
+
 const exparg_n = log(nextfloat(floatmin(Float64)))
 const exparg_p =  log(prevfloat(floatmax(Float64)))
 
@@ -60,6 +59,7 @@ function stirling_corr(a0::Float64, b0::Float64)
     t = inv(b)^2
     w = @horner(t, .833333333333333E-01, -.277777777760991E-02*s₃, .793650666825390E-03*s₅, -.595202931351870E-03*s₇, .837308034031215E-03*s₉, -.165322962780713E-02*s₁₁)
     w *= c/b
+
     # COMPUTE stirling(a) + w
     t = inv(a)^2
     return @horner(t, .833333333333333E-01, -.277777777760991E-02, .793650666825390E-03, -.595202931351870E-03, .837308034031215E-03, -.165322962780713E-02)/a + w

--- a/src/ellip.jl
+++ b/src/ellip.jl
@@ -1,8 +1,3 @@
-using Base.Math: @horner
-
-
-
-
 @doc raw"""
     ellipk(m)
 

--- a/src/erf.jl
+++ b/src/erf.jl
@@ -1,8 +1,4 @@
 # This file contains code that was formerly a part of Julia. License is MIT: http://julialang.org/license
-
-using Base.Math: @horner, libm
-using Base.MPFR: ROUNDING_MODE
-
 for f in (:erf, :erfc)
     @eval begin
         ($f)(x::Float64) = ccall(($(string(f)),libm), Float64, (Float64,), x)

--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -1,7 +1,4 @@
 # This file contains code that was formerly a part of Julia. License is MIT: http://julialang.org/license
-
-using Base.MPFR: ROUNDING_MODE, big_ln2
-
 const ComplexOrReal{T} = Union{T,Complex{T}}
 
 # Bernoulli numbers B_{2k}, using tabulated numerators and denominators from

--- a/src/gamma_inc.jl
+++ b/src/gamma_inc.jl
@@ -1,5 +1,3 @@
-using Base.Math: @horner
-using Base.MPFR: ROUNDING_MODE
 #useful constants
 const acc0 = [5.0e-15 , 5.0e-7 , 5.0e-4] #accuracy options
 const big1 = [25.0 , 14.0, 10.0]

--- a/src/prelude.jl
+++ b/src/prelude.jl
@@ -1,0 +1,5 @@
+#prelude.jl
+
+#some common imports used by almost all scripts:
+using Base.MPFR: ROUNDING_MODE, big_ln2
+using Base.Math: @horner, libm, nan_dom_err


### PR DESCRIPTION
i just compiled a list of consts and using statements in each script:

## Usings:
### bessel
```julia
using Base.Math: nan_dom_err
```
```julia
using Base.Math: @horner
using Base.MPFR: ROUNDING_MODE
```
### ellip
```julia
using Base.Math: @horner
```
### erf
```julia
using Base.Math: @horner, libm
using Base.MPFR: ROUNDING_MODE
```
### gamma_inc
```julia
using Base.Math: @horner
using Base.MPFR: ROUNDING_MODE
```
### gamma
```julia
using Base.MPFR: ROUNDING_MODE, big_ln2
```
### sicosint
```julia
using Base.Math: @horner
```
# consts:
### beta_inc:
```julia
const exparg_n = log(nextfloat(floatmin(Float64)))
const exparg_p =  log(prevfloat(floatmax(Float64)))
```
### betanc
```julia
const errmax = 1e-15
```
### gamma_inc
```julia
const acc0 = [5.0e-15 , 5.0e-7 , 5.0e-4] #accuracy options
const big1 = [25.0 , 14.0, 10.0]
const e0 = [0.25e-3 , 0.25e-1 , 0.14]
const x0=[31.0 , 17.0 , 9.7]
const alog10 = log(10)
const rt2pin = 1.0/sqrt(2*pi)
const rtpi = sqrt(pi)
const exparg = -745.1
const stirling_coef = [1.996379051590076518221, -0.17971032528832887213e-2, 0.131292857963846713e-4, -0.2340875228178749e-6, 0.72291210671127e-8, -0.3280997607821e-9, 0.198750709010e-10, -0.15092141830e-11, 0.1375340084e-12, -0.145728923e-13, 0.17532367e-14, -0.2351465e-15, 0.346551e-16, -0.55471e-17, 0.9548e-18, -0.1748e-18, 0.332e-19, -0.58e-20]
const auxgam_coef = [-1.013609258009865776949, 0.784903531024782283535e-1, 0.67588668743258315530e-2, -0.12790434869623468120e-2, 0.462939838642739585e-4, 0.43381681744740352e-5, -0.5326872422618006e-6, 0.172233457410539e-7, 0.8300542107118e-9, -0.10553994239968e-9, 0.39415842851e-11, 0.362068537e-13, -0.107440229e-13, 0.5000413e-15, -0.62452e-17, -0.5185e-18, 0.347e-19, -0.9e-21]
const d00 = -.333333333333333E+00
const d0=[.833333333333333E-01 , -.148148148148148E-01 , .115740740740741E-02 , .352733686067019E-03 , -.178755144032922E-03 , .391926317852244E-04]
const d10 = -.185185185185185E-02
const d1=[-.347222222222222E-02 , .264550264550265E-02 , -.990226337448560E-03 , .205761316872428E-03]
const d20 = .413359788359788E-02
const d2=[-.268132716049383E-02 , .771604938271605E-03]
const d30 = .649434156378601E-03
const d3=[.229472093621399E-03 , -.469189494395256E-03]
const d40 = -.861888290916712E-03
const d4=[.784039221720067E-03]
const d50 = -.336798553366358E-03
const d5=[-.697281375836586E-04]
const d60 = .531307936463992E-03
const d6=[-.592166437353694E-03]
const d70 = .344367606892378E-03
const d80 = -.652623918595309E-03
const ComplexOrReal{T} = Union{T,Complex{T}}
```
### gamma:
```julia
const cotderiv_Q = [cotderiv_q(m) for m in 1:100]
```
in summary, a lot of repeated `using` statements. this pull request is targeted towards ordering where possible. starting by adding all the repeated statements on the `prelude.jl` file. there are also a lot of constants that can be directly inlined.