### PR TITLE
Update .cirrus file

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,11 +1,12 @@
 freebsd_instance:
-  image: freebsd-12-0-release-amd64
+  image: freebsd-12-1-release-amd64
 task:
   name: FreeBSD
   env:
     matrix:
-        JULIA_VERSION: 1.3
+        JULIA_VERSION: 1.4
         JULIA_VERSION: nightly
+  allow_failures: $JULIA_VERSION == 'nightly'
   install_script:
     - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"
   build_script:


### PR DESCRIPTION
_use current freebsd image_: hopefully this fixes the errors of the curris tests in pull request #175 .

_current julia version_: should always be the current one. 
if we just write "JULIA_VERSION: 1" then it uses the most current major version 1.x automatically. 

_allow nightly builds to fail_: nightly builds might be buggy...