### PR TITLE
Stop allowing failures on Julia nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ os:
 julia:
   - 1
   - nightly
-matrix:
-  allow_failures:
-    - julia: nightly
 notifications:
   email: false
 coveralls: true


### PR DESCRIPTION
Since `jobs` and `matrix` are aliases for one another, specifying both might have removed the documentation job(??). We don't need to allow failures on Julia nightly now that an upstream thing has been fixed, so removing the `matrix:` section should hopefully bring the doc build back.