### PR TITLE
Update the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,13 @@ Special mathematical functions in Julia, including Bessel, Hankel, Airy, error, 
 eta, zeta, digamma, inverse digamma, trigamma, and polygamma functions.
 Most of these functions were formerly part of Base in early versions of Julia.
 
-This package downloads and builds [openspecfun](https://github.com/JuliaLang/openspecfun).
-Binaries are available for macOS, Windows, FreeBSD, and Linux (glibc >= 2.6 and musl).
-
-| System | Test Status |
-| :----- | :---------: |
-| Linux/macOS | [![Travis](https://travis-ci.org/JuliaMath/SpecialFunctions.jl.svg?branch=master)](https://travis-ci.org/JuliaMath/SpecialFunctions.jl) |
-| Windows | [![AppVeyor](https://ci.appveyor.com/api/projects/status/ccfgkm2cjcggu158/branch/master?svg=true)](https://ci.appveyor.com/project/ararslan/specialfunctions-jl/branch/master) |
-| FreeBSD | [![Cirrus](https://api.cirrus-ci.com/github/JuliaMath/SpecialFunctions.jl.svg)](https://cirrus-ci.com/github/JuliaMath/SpecialFunctions.jl) |
-
-Coverage:
+CI (Linux, macOS, FreeBSD, Windows):
+[![Travis](https://travis-ci.org/JuliaMath/SpecialFunctions.jl.svg?branch=master)](https://travis-ci.org/JuliaMath/SpecialFunctions.jl)
 [![Coveralls](https://coveralls.io/repos/github/JuliaMath/SpecialFunctions.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaMath/SpecialFunctions.jl?branch=master)
 
 Documentation:
-[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaMath.github.io/SpecialFunctions.jl/stable)
-[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://JuliaMath.github.io/SpecialFunctions.jl/latest)
+[![Documentation](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaMath.github.io/SpecialFunctions.jl/stable)
+[![Documentation](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaMath.github.io/SpecialFunctions.jl/dev)
+
+Test status (most recent release):
+[![PkgEval](https://juliaci.github.io/NanosoldierReports/pkgeval_badges/S/SpecialFunctions.svg)](https://juliaci.github.io/NanosoldierReports/pkgeval_badges/report.html)


### PR DESCRIPTION
There are a few inaccuracies:
* The package no longer downloads and builds openspecfun; instead, it uses OpenSpecFun_jll as a dependency.
* We're no longer using AppVeyor or Cirrus.
* Documenter now wants people to use "dev" instead of "latest" for docs built from master.

Further, we can re-add a [status badge from PkgEval](https://discourse.julialang.org/t/ann-nanosoldier-package-evaluation-with-badges/33339) like the good old days.

[See here](https://github.com/JuliaMath/SpecialFunctions.jl/blob/a9ca31c9746663ddd63cb22de56ee239d6680620/README.md) for a rendered preview.