### PR TITLE
renenable ChainRules tests now that ChainRulesTestUtils is fixed

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ OpenSpecFun_jll = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
 
 [compat]
 ChainRulesCore = "0.9"
+ChainRulesTestUtils = "0.5.10"
 OpenSpecFun_jll = "0.5"
 julia = "1.3"
 

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -66,7 +66,7 @@
                 Δx, x̄ = randn(2)
                 Δz = (randn(), randn())
 
-                # frule_test(logabsgamma, (x, Δx))   # uncomment when #288 is fixed
+                frule_test(logabsgamma, (x, Δx))
                 rrule_test(logabsgamma, Δz, (x, x̄))
             end
         end


### PR DESCRIPTION
Undoes #289 since the root cause of #288 is fixed.