### PR TITLE
update to new ChainRulesTestUtils

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ OpenSpecFun_jll = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
 
 [compat]
 ChainRulesCore = "0.9"
-ChainRulesTestUtils = "0.5.10"
+ChainRulesTestUtils = "0.5.10, 0.6"
 OpenSpecFun_jll = "0.5"
 julia = "1.3"
 


### PR DESCRIPTION
The new version of ChainRulesTestUtils:
 - uses a new version of FiniteDifferences slightly faster and has some features for constraining maximum range
 - Checks the rules are inferable
 
 
This passes on 1.5 for me.
It may not on older version when julia's type inference was worse, if so i will add come conditionals to disable it.