### PR TITLE
removed factorial

### DIFF
--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -884,13 +884,6 @@ end
 
 ## from base/numbers.jl
 
-# this trickery is needed while the deprecated method in Base exists
-@static if !hasmethod(Base.factorial, Tuple{Number})
-    import Base: factorial
-end
-factorial(x) = Base.factorial(x) # to make SpecialFunctions.factorial work unconditionally
-factorial(x::Number) = gamma(x + 1) # fallback for x not Integer
-
 """
     logabsbinomial(n, k)
 

--- a/test/gamma.jl
+++ b/test/gamma.jl
@@ -72,10 +72,6 @@
         @test loggamma(1.4+3.7im) ≈ -3.7094025330996841898 + 2.4568090502768651184im
         @test loggamma(1.4+3.7im) ≈ log(gamma(1.4+3.7im))
         @test loggamma(-4.2+0im) ≈ logabsgamma(-4.2)[1] - 5pi*im
-        @test SpecialFunctions.factorial(3.0) == gamma(4.0) == factorial(3)
-        for x in (3.2, 2+1im, 3//2, 3.2+0.1im)
-            @test SpecialFunctions.factorial(x) == gamma(1+x)
-        end
         @test logfactorial(0) == logfactorial(1) == 0
         @test logfactorial(2) == loggamma(3)
         # Ensure that the domain of logfactorial matches that of factorial (issue #21318)


### PR DESCRIPTION
`Base.factorial` is extended in SpecialFunction.jl.

This is _type piracy_ and doesn't follow [Julia's style guide](https://docs.julialang.org/en/v1/manual/style-guide/#Avoid-type-piracy).

There is at least one problem with it for which we did not find a solution so far:
The method [`Base.factorial(x::BigFloat)`](https://github.com/JuliaLang/julia/blob/68133407404f3e1221385d495b47eb8585b258af/base/mpfr.jl#L640) assumes `x::UInt` and therefor, we cannot overwrite it using the `gamma` function for arbitrary `BigFloat`s. There is also an issue #232 for it.

As stated by stevengj at issue #296 one should much rather just call `gamma` for non-integer arguments directly. Thus, there is no need for an extended `factorial` function.