### PR TITLE
use new ChainRulesTestUtils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ matrix:
 notifications:
   email: false
 
+env:
+  # Disable PkgServer
+  - JULIA_PKG_SERVER=""
+
 branches:
   only:
   - master

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ OpenSpecFun_jll = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
 
 [compat]
 ChainRulesCore = "0.9"
-ChainRulesTestUtils = "0.5.10, 0.6"
+ChainRulesTestUtils = "0.6.3"
 OpenSpecFun_jll = "0.5"
 julia = "1.3"
 

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -41,17 +41,11 @@
             for _x in test_points, _y in test_points
                 # ensure all complex if any complex for FiniteDifferences
                 x, y = promote(_x, _y)
-                T = typeof(x)
+                test_frule(beta, x, y)
+                test_rrule(beta, x, y)
 
-                Δx, x̄ = randn(T, 2)
-                Δy, ȳ = randn(T, 2)
-                Δz = randn(T)
-
-                frule_test(beta, (x, Δx), (y, Δy))
-                rrule_test(beta, Δz, (x, x̄), (y, ȳ))
-
-                frule_test(logbeta, (x, Δx), (y, Δy))
-                rrule_test(logbeta, Δz, (x, x̄), (y, ȳ))
+                test_frule(logbeta, x, y)
+                test_rrule(logbeta, x, y)
             end
         end
 
@@ -62,12 +56,8 @@
                 test_scalar(loggamma, x)
 
                 isreal(x) || continue
-
-                Δx, x̄ = randn(2)
-                Δz = (randn(), randn())
-
-                frule_test(logabsgamma, (x, Δx))
-                rrule_test(logabsgamma, Δz, (x, x̄))
+                test_frule(logabsgamma, x)
+                test_rrule(logabsgamma, x; output_tangent=(randn(), randn()))
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 # This file contains code that was formerly a part of Julia. License is MIT: http://julialang.org/license
 
 using SpecialFunctions
+using ChainRulesCore
 using ChainRulesTestUtils
 using Random
 using Test


### PR DESCRIPTION
in https://github.com/JuliaDiff/ChainRulesTestUtils.jl/pull/116
we deprecated `rrule_test` and `frule_test` for newer nicer versions that didn't require providing tangents youself.

Except in exceptional cases. Which apprently `logabsdet` is for its output (still improved for its input).
I kind of knew that going in, though I am still not 100% convinced we couldn't make ChainRulesTestUtils/FiniteDifferences handle that better.