### PR TITLE
Use LogExpFunctions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,16 @@
 name = "SpecialFunctions"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "1.3"
+version = "1.3.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 OpenSpecFun_jll = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
 
 [compat]
 ChainRulesCore = "0.9"
 ChainRulesTestUtils = "0.6.3"
+LogExpFunctions = "0.2"
 OpenSpecFun_jll = "0.5"
 julia = "1.3"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SpecialFunctions"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "1.3.0"
+version = "1.4.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/SpecialFunctions.jl
+++ b/src/SpecialFunctions.jl
@@ -1,6 +1,7 @@
 module SpecialFunctions
 
 import ChainRulesCore
+import LogExpFunctions
 
 using OpenSpecFun_jll
 

--- a/src/beta_inc.jl
+++ b/src/beta_inc.jl
@@ -109,9 +109,9 @@ function beta_integrand(a::Float64,b::Float64,x::Float64,y::Float64,mu::Float64=
              lambda = a - (a+b)*x
         end
         e = -lambda/a
-        u = abs(e) > 0.6 ? u = e - log(x/x0) : - log1pmx(e)
+        u = abs(e) > 0.6 ? e - log(x/x0) : - LogExpFunctions.log1pmx(e)
         e = lambda/b
-        v = abs(e) > 0.6 ? e - log(y/y0) : - log1pmx(e)
+        v = abs(e) > 0.6 ? e - log(y/y0) : - LogExpFunctions.log1pmx(e)
         z = esum(mu, -(a*u + b*v))
         return (1.0/sqrt(2*pi))*sqrt(b*x0)*z*exp(-stirling_corr(a,b))
     elseif x > 0.375
@@ -271,7 +271,7 @@ function beta_inc_asymptotic_symmetric(a::Float64, b::Float64, lambda::Float64, 
         r1 = (b-a)/b
         w0 = 1.0/sqrt(a*(1.0+h))
     end
-    f = -a*log1pmx(-(lambda/a)) - b*log1pmx((lambda/b))
+    f = -a*LogExpFunctions.log1pmx(-(lambda/a)) - b*LogExpFunctions.log1pmx(lambda/b)
     t = exp(-f)
     if t == 0.0
         return ans


### PR DESCRIPTION
This PR removes the implementation of `log1pmx` and `logmxp1` and use the definitions in LogExpFunctions instead.

The code for `log1pmx` and `logmxp1` was copied from StatsFuns at some point (https://github.com/JuliaMath/SpecialFunctions.jl/pull/146#discussion_r261888987), probably to avoid the dependency on StatsFuns and its Rmath dependency. The log/exp related functions were moved from StatsFuns to LogExpFunctions recently which does only depend on LinearAlgebra and DocStringExtensions (which itself only depends on LibGit2).