### PR TITLE
Generalize three-argument version of `beta_inc`

### DIFF
--- a/src/beta_inc.jl
+++ b/src/beta_inc.jl
@@ -876,7 +876,7 @@ function beta_inc(a::Float64, b::Float64, x::Float64, y::Float64)
     return ind ? (q, p) : (p, q)
 end
 
-beta_inc(a::Float64, b::Float64, x::Float64) = beta_inc(a, b, x, 1.0 - x)
+beta_inc(a::Real, b::Real, x::Real) = beta_inc(a, b, x, 1 - x)
 function beta_inc(a::T, b::T, x::T, y::T) where {T<:Union{Float16, Float32}}
     T.(beta_inc(Float64(a), Float64(b), Float64(x), Float64(y)))
 end

--- a/test/beta_inc.jl
+++ b/test/beta_inc.jl
@@ -218,10 +218,13 @@
         @test beta_inc(a, b, x, 1 - x) isa Tuple{T,T}
         @test beta_inc(a, b, x) == beta_inc(a, b, x, 1 - x)
     end
-    a, b = randexp(2)
-    x = rand()
-    @test beta_inc(a, Float32(b), x) == beta_inc(a, b, x)
-    @test beta_inc(a, Float32(b), Float32(x), 1-x) == beta_inc(a, b, x, 1-x)
+    a = randexp()
+    b = randexp(Float32)
+    x = rand(Float32)
+    @test beta_inc(a, b, x) isa Tuple{Float64,Float64}
+    @test beta_inc(a, b, x) == beta_inc(a, Float64(b), Float64(x))
+    @test beta_inc(a, b, x, 1 - x) isa Tuple{Float64,Float64}
+    @test beta_inc(a, b, x, 1 - x) == beta_inc(a, Float64(b), Float64(x), 1 - x)
 
     @test SpecialFunctions.loggammadiv(13.89, 21.0001) ≈ log(gamma(big(21.0001))/gamma(big(21.0001)+big(13.89)))
     @test SpecialFunctions.stirling_corr(11.99, 100.1) ≈ SpecialFunctions.stirling_error(11.99) + SpecialFunctions.stirling_error(100.1) - SpecialFunctions.stirling_error(11.99 + 100.1)

--- a/test/beta_inc.jl
+++ b/test/beta_inc.jl
@@ -210,6 +210,19 @@
     @test beta_inc(1.5, 200.5,  0.07,0.93)[1] ≈ 0.99999790408564
     @test beta_inc(1e-20, 0.000001, 0.2)[2] ≈ 1.0000013862929421e-14
 
+    # test promotions and return types
+    for T in (Float64, Float32)
+        a, b = randexp(T, 2)
+        x = rand(T)
+        @test beta_inc(a, b, x) isa Tuple{T,T}
+        @test beta_inc(a, b, x, 1 - x) isa Tuple{T,T}
+        @test beta_inc(a, b, x) == beta_inc(a, b, x, 1 - x)
+    end
+    a, b = randexp(2)
+    x = rand()
+    @test beta_inc(a, Float32(b), x) == beta_inc(a, b, x)
+    @test beta_inc(a, Float32(b), Float32(x), 1-x) == beta_inc(a, b, x, 1-x)
+
     @test SpecialFunctions.loggammadiv(13.89, 21.0001) ≈ log(gamma(big(21.0001))/gamma(big(21.0001)+big(13.89)))
     @test SpecialFunctions.stirling_corr(11.99, 100.1) ≈ SpecialFunctions.stirling_error(11.99) + SpecialFunctions.stirling_error(100.1) - SpecialFunctions.stirling_error(11.99 + 100.1)
 end


### PR DESCRIPTION
This PR addresses https://github.com/JuliaStats/StatsFuns.jl/pull/113#discussion_r635611942 and generalizes the three-argument version of `beta_inc` which seems to be defined for `Float64` only, although the four-argument version is defined for more general arguments.