### PR TITLE
use new ChainRulesCore

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,8 +8,8 @@ LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 OpenSpecFun_jll = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
 
 [compat]
-ChainRulesCore = "0.9.40"
-ChainRulesTestUtils = "0.6.8"
+ChainRulesCore = "0.9.44, 0.10"
+ChainRulesTestUtils = "0.6.8, 0.7"
 LogExpFunctions = "0.2"
 OpenSpecFun_jll = "0.5"
 julia = "1.3"

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -105,7 +105,7 @@ ChainRulesCore.@scalar_rule(
 ChainRulesCore.@scalar_rule(
     polygamma(m, x),
     (
-        ChainRulesCore.DoesNotExist(),
+        ChainRulesCore.NoTangent(),
         polygamma(m + 1, x),
     ),
 )
@@ -122,7 +122,11 @@ ChainRulesCore.@scalar_rule(
 )
 
 # actually is the absolute value of the logorithm of gamma paired with sign gamma
-ChainRulesCore.@scalar_rule(logabsgamma(x), digamma(x), ChainRulesCore.Zero())
+ChainRulesCore.@scalar_rule(
+    logabsgamma(x),
+    digamma(x),
+    ChainRulesCore.ZeroTangent()
+)
 
 ChainRulesCore.@scalar_rule(loggamma(x), digamma(x))
 ChainRulesCore.@scalar_rule(


### PR DESCRIPTION
This prepares for the new ChainRulesCore release.
In this case it is mutually compatible with one of the prior releases.

Moving to 0.7 will close #310  

CI will likely fail til everything is tagged, should be all working no later than tomorrow