### PR TITLE
relax ChainRules test on polygamma

### DIFF
--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -84,8 +84,8 @@
         test_points = (1.5, 2.5, 10.5, -0.6, -2.6, -3.3, 1.6 + 1.6im, 1.6 - 1.6im, -4.6 + 1.6im)
         for x in test_points
             for m in (0, 1, 2, 3)
-                test_frule(polygamma, m, x)
-                test_rrule(polygamma, m, x)
+                test_frule(polygamma, m, x; rtol=1e-8)
+                test_rrule(polygamma, m, x; rtol=1e-8)
             end
 
             isreal(x) && x < 0 && continue


### PR DESCRIPTION
In https://github.com/JuliaDiff/FiniteDifferences.jl/pull/168#issuecomment-852082528
it was found that by testing with different tangent values being propagated this test failed.
That kind of means we just got lucky that we didn't see this other times.

I think that means that `polygamma` is just a bit too hard to finite difference to 1e-9, so we can relax it to 1e-8.
Which matches what we do for `gamma` anyway