### PR TITLE
Revert change of OpenSpecFun_jll compat bound

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ OpenSpecFun_jll = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
 ChainRulesCore = "0.9.40"
 ChainRulesTestUtils = "0.6.8"
 LogExpFunctions = "0.2"
-OpenSpecFun_jll = "0.5.5"
+OpenSpecFun_jll = "0.5"
 julia = "1.3"
 
 [extras]


### PR DESCRIPTION
I just noticed that tests fail due to https://github.com/JuliaMath/SpecialFunctions.jl/commit/d289335bb6bbf8fa455aeb47566cbe08d48f630c. OpenSpecFun_jll >= 0.5.4 is only compatible with Julia >= 1.6 it seems, I guess it was not intended to drop support fro Julia < 1.6?