### PR TITLE
Update Project.toml to use openspecfun 0.5.5 and julia 1.6

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 ---
 kind: pipeline
-name: linux - arm - Julia 1.3
+name: linux - arm - Julia 1.6
 
 platform:
   os: linux
@@ -8,13 +8,13 @@ platform:
 
 steps:
 - name: build
-  image: julia:1.3
+  image: julia:1.6
   commands:
   - "julia --project=. --check-bounds=yes --color=yes -e 'using InteractiveUtils; versioninfo(verbose=true); using Pkg; Pkg.build(); Pkg.test(coverage=true)'"
 
 ---
 kind: pipeline
-name: linux - arm64 - Julia 1.3
+name: linux - arm64 - Julia 1.6
 
 platform:
   os: linux
@@ -22,7 +22,7 @@ platform:
 
 steps:
 - name: build
-  image: julia:1.3
+  image: julia:1.6
   commands:
   - "julia --project=. --check-bounds=yes --color=yes -e 'using InteractiveUtils; versioninfo(verbose=true); using Pkg; Pkg.build(); Pkg.test(coverage=true)'"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - "1"
           - "1.6"
           - "nightly"
         os:
@@ -53,7 +54,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: "1.6"
+          version: "1"
       - uses: julia-actions/julia-docdeploy@releases/v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.3"
-          - "1"
+          - "1.6"
           - "nightly"
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: "1"
+          version: "1.6"
       - uses: julia-actions/julia-docdeploy@releases/v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - freebsd
 julia:
   - 1.6
-  - 1
   - nightly
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: julia
 os:
   - freebsd
 julia:
-  - 1.3
+  - 1.6
   - 1
   - nightly
 matrix:

--- a/Project.toml
+++ b/Project.toml
@@ -11,8 +11,8 @@ OpenSpecFun_jll = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
 ChainRulesCore = "0.9.40"
 ChainRulesTestUtils = "0.6.8"
 LogExpFunctions = "0.2"
-OpenSpecFun_jll = "0.5"
-julia = "1.3"
+OpenSpecFun_jll = "0.5.5"
+julia = "1.6"
 
 [extras]
 ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SpecialFunctions"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "1.4.3"
+version = "1.5.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"


### PR DESCRIPTION
This PR bumps the Julia minimum version to 1.6, in order to use openspecfun v0.5.5 (which pulls in a fix for https://github.com/JuliaPackaging/BinaryBuilderBase.jl/issues/92).

I am considering bumping the SpecialFunctions.jl version to 1.5, so that Julia 1.6 and higher can continue to lower bound and always pick up the fixed openspecfun. There are no reported problems that necessitate the fix, so older releases should continue to be fine. We just pick this up going forward.