### PR TITLE
Fix `logabsbeta` for BigFloat

### DIFF
--- a/src/beta_inc.jl
+++ b/src/beta_inc.jl
@@ -11,7 +11,8 @@ Computes ``log(\\Gamma(b)/\\Gamma(a+b))`` when b >= 8
 """
 loggammadiv(a::Number, b::Number) = _loggammadiv(promote(float(a), float(b))...)
 
-_loggammadiv(a::Number, b::Number) = loggamma(b) - loggamma(a + b)
+# TODO: Add a proper implementation
+_loggammadiv(a::Number, b::Number) = loggamma(b) - loggamma(a + b) # handle e.g. BigFloat (used by `logabsbeta`)
 _loggammadiv(a::T, b::T) where {T<:Base.IEEEFloat} = T(_loggammadiv(Float64(a), Float64(b))) # handle Float16, Float32
 function _loggammadiv(a::Float64, b::Float64)
     @assert b >= 8

--- a/src/beta_inc.jl
+++ b/src/beta_inc.jl
@@ -9,8 +9,9 @@ const exparg_p =  log(prevfloat(floatmax(Float64)))
 
 Computes ``log(\\Gamma(b)/\\Gamma(a+b))`` when b >= 8
 """
-loggammadiv(a::Number, b::Number) = _loggammadiv(float(a), float(b))
+loggammadiv(a::Number, b::Number) = _loggammadiv(promote(float(a), float(b))...)
 
+_loggammadiv(a::Number, b::Number) = loggamma(b) - loggamma(a + b)
 _loggammadiv(a::T, b::T) where {T<:Base.IEEEFloat} = T(_loggammadiv(Float64(a), Float64(b))) # handle Float16, Float32
 function _loggammadiv(a::Float64, b::Float64)
     @assert b >= 8

--- a/test/beta_inc.jl
+++ b/test/beta_inc.jl
@@ -227,6 +227,7 @@
     @test beta_inc(a, b, x, 1 - x) == beta_inc(a, Float64(b), Float64(x), 1 - x)
 
     @test SpecialFunctions.loggammadiv(13.89, 21.0001) ≈ log(gamma(big(21.0001))/gamma(big(21.0001)+big(13.89)))
+    @test SpecialFunctions.loggammadiv(big(13.89), big(21.0001)) ≈ log(gamma(big(21.0001))/gamma(big(21.0001)+big(13.89)))
     @test SpecialFunctions.stirling_corr(11.99, 100.1) ≈ SpecialFunctions.stirling_error(11.99) + SpecialFunctions.stirling_error(100.1) - SpecialFunctions.stirling_error(11.99 + 100.1)
 end
 

--- a/test/gamma.jl
+++ b/test/gamma.jl
@@ -274,6 +274,24 @@ end
         @test logabsbeta(1e8, 0.5)[1] ≈ log(0.00017724538531210809)       rtol=1e-14
     end
 
+    @testset "BigFloat" begin
+        @test beta(big(3), big(5)) ≈ inv(big(105))
+        @test beta(big(3//2), big(7//2)) ≈ 5 * big(π) / 128
+        @test beta(big(1e4), big(3//2)) ≈ 8.86193693673874630607029e-7 rtol=1e-14
+        @test beta(big(1e8), big(1//2)) ≈ 0.00017724538531210809 rtol=1e-14
+
+        @test logbeta(big(5), big(4)) ≈ log(beta(big(5), big(4)))
+        @test logbeta(big(5.0), big(4)) ≈ log(beta(big(5), big(4)))
+        @test logbeta(big(1e4), big(3//2)) ≈ log(8.86193693673874630607029e-7) rtol=1e-14
+        @test logbeta(big(1e8), big(1//2)) ≈ log(0.00017724538531210809) rtol=1e-14
+
+        @test logabsbeta(-big(2), big(2))[1] ≈ -log(big(2))
+        @test logabsbeta(-big(2.0), big(2))[1] ≈ -log(big(2))
+        @test logabsbeta(-big(2), big(2//1))[1] ≈ -log(big(2))
+        @test logabsbeta(big(1e4), big(3//2))[1] ≈ log(8.86193693673874630607029e-7) rtol=1e-14
+        @test logabsbeta(big(1e8), big(1//2))[1] ≈ log(0.00017724538531210809) rtol=1e-14
+    end
+
     @test beta(-1/2, 3) ≈ beta(-1/2 + 0im, 3 + 0im) ≈    -16/3
     @test logabsbeta(-1/2, 3)[1]                    ≈ log(16/3)
     @test beta(Float32(5), Float32(4))             == beta(Float32(4), Float32(5))


### PR DESCRIPTION
This PR adds a fallback definition for `_loggammadiv`. This fixes test errors in https://github.com/TuringLang/DistributionsAD.jl/pull/172.

**Motivation:**
Version 1.4.1, or more concretely https://github.com/JuliaMath/SpecialFunctions.jl/pull/316 (@andreasnoack), caused some regressions of `logbeta` and `logabsbeta` with `BigFloat`s.

On 1.4.0:
```julia
julia> using SpecialFunctions

julia> beta(big(nextfloat(0.0)), big(nextfloat(8.0)))
2.024022533073106183524953467189173070495566497641421183569013580274303395679953e+323

julia> logbeta(big(nextfloat(0.0)), big(nextfloat(8.0)))
744.4400719213812623141072984460816341130871443029141429256103301959047499954517

julia> logabsbeta(big(nextfloat(0.0)), big(nextfloat(8.0)))
(744.4400719213812623141072984460816341130871443029141429256103301959047499954517, 1)
```

On 1.4.1:
```julia
julia> beta(big(nextfloat(0.0)), big(nextfloat(8.0)))
2.024022533073106183524953467189173070495566497641421183569013580274303395679953e+323

julia> logbeta(big(nextfloat(0.0)), big(nextfloat(8.0)))
ERROR: MethodError: no method matching _loggammadiv(::BigFloat, ::BigFloat)
Stacktrace:
 [1] loggammadiv(a::BigFloat, b::BigFloat)
   @ SpecialFunctions ~/.julia/packages/SpecialFunctions/W3J2O/src/beta_inc.jl:12
 [2] logabsbeta(a::BigFloat, b::BigFloat)
   @ SpecialFunctions ~/.julia/packages/SpecialFunctions/W3J2O/src/gamma.jl:822
 [3] logbeta(a::BigFloat, b::BigFloat)
   @ SpecialFunctions ~/.julia/packages/SpecialFunctions/W3J2O/src/gamma.jl:788
 [4] top-level scope
   @ REPL[15]:1

julia> logabsbeta(big(nextfloat(0.0)), big(nextfloat(8.0)))
ERROR: MethodError: no method matching _loggammadiv(::BigFloat, ::BigFloat)
Stacktrace:
 [1] loggammadiv(a::BigFloat, b::BigFloat)
   @ SpecialFunctions ~/.julia/packages/SpecialFunctions/W3J2O/src/beta_inc.jl:12
 [2] logabsbeta(a::BigFloat, b::BigFloat)
   @ SpecialFunctions ~/.julia/packages/SpecialFunctions/W3J2O/src/gamma.jl:822
 [3] top-level scope
   @ REPL[16]:1
```

`beta` still works since it uses the definition in mpfr on my machine. Actually, the problem was present in SpecialFunctions 1.4.0 as well but it is easier to trigger it in 1.4.1 since the branch is chosen not only for inputs with large difference in magnitude anymore (on 1.4.0: https://github.com/JuliaMath/SpecialFunctions.jl/blob/feccbf44f8a8caed9a8eb85d4025c8859b9ab537/src/gamma.jl#L842, on 1.4.1: https://github.com/JuliaMath/SpecialFunctions.jl/blob/dd414811d6eb3538d4e1b5b0f42f8f15d8ec77a0/src/gamma.jl#L821).

On 1.4.0:
```julia
julia> logabsbeta(big(nextfloat(1e5)), big(1.0))
ERROR: MethodError: no method matching _loggammadiv(::BigFloat, ::BigFloat)
Stacktrace:
 [1] loggammadiv(a::BigFloat, b::BigFloat)
   @ SpecialFunctions ~/.julia/packages/SpecialFunctions/L13jJ/src/beta_inc.jl:12
 [2] logabsbeta(a::BigFloat, b::BigFloat)
   @ SpecialFunctions ~/.julia/packages/SpecialFunctions/L13jJ/src/gamma.jl:843
 [3] top-level scope
   @ REPL[14]:1
```

With this PR all examples work:
```julia
julia> beta(big(nextfloat(0.0)), big(nextfloat(8.0)))
2.024022533073106183524953467189173070495566497641421183569013580274303395679953e+323

julia> logbeta(big(nextfloat(0.0)), big(nextfloat(8.0)))
744.4400719213812623141072984460816341130871443029141429256103301959047499954517

julia> logabsbeta(big(nextfloat(0.0)), big(nextfloat(8.0)))
(744.4400719213812623141072984460816341130871443029141429256103301959047499954517, 1)

julia> logabsbeta(big(nextfloat(1e5)), big(1.0))
(-11.51292546497022856560910955709032851649991676439065368877238753498953004770512, 1)
```