### PR TITLE
Test thunked tangents

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ OpenSpecFun_jll = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
 
 [compat]
 ChainRulesCore = "0.9.44, 0.10"
-ChainRulesTestUtils = "0.7.10"
+ChainRulesTestUtils = "0.7.13"
 LogExpFunctions = "0.2"
 OpenSpecFun_jll = "0.5"
 julia = "1.3"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SpecialFunctions"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "1.5.1"
+version = "1.5.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -9,7 +9,7 @@ OpenSpecFun_jll = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
 
 [compat]
 ChainRulesCore = "0.9.44, 0.10"
-ChainRulesTestUtils = "0.6.8, 0.7"
+ChainRulesTestUtils = "0.7.10"
 LogExpFunctions = "0.2"
 OpenSpecFun_jll = "0.5"
 julia = "1.3"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,12 +37,9 @@ tests = [
 
 const testdir = dirname(@__FILE__)
 
-# TRANSFORMS_TO_ALT_TANGENTS is a list (presently empty) of transformations
-# which take a tangent to an alternative tangent. The rules are tested to
-# that they also support receiving alternative tangents. See
-# https://github.com/JuliaMath/SpecialFunctions.jl/pull/329#discussion_r658178389
-# for more details.
-push!(ChainRulesTestUtils.TRANSFORMS_TO_ALT_TANGENTS, x -> @thunk(x))
+# Transitional feature, see
+# https://juliadiff.org/ChainRulesTestUtils.jl/dev/api.html#ChainRulesTestUtils.enable_tangent_transform!
+ChainRulesTestUtils.enable_tangent_transform!(Thunk)
 
 for t in tests
     tp = joinpath(testdir, "$(t).jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,7 @@ tests = [
 
 const testdir = dirname(@__FILE__)
 
+push!(ChainRulesTestUtils.TRANSFORMS_TO_ALT_TANGENTS, x -> @thunk(x))
 
 for t in tests
     tp = joinpath(testdir, "$(t).jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,11 @@ tests = [
 
 const testdir = dirname(@__FILE__)
 
+# TRANSFORMS_TO_ALT_TANGENTS is a list (presently empty) of transformations
+# which take a tangent to an alternative tangent. The rules are tested to
+# that they also support receiving alternative tangents. See
+# https://github.com/JuliaMath/SpecialFunctions.jl/pull/329#discussion_r658178389
+# for more details.
 push!(ChainRulesTestUtils.TRANSFORMS_TO_ALT_TANGENTS, x -> @thunk(x))
 
 for t in tests


### PR DESCRIPTION
With the 1.0 release of ChainRules ecosystem (coming up soon), rules will need to support receiving thunked tangents. This PR expands the tests for all the rules to include receiving a thunked tangent.