### PR TITLE
Support ChainRulesCore v1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SpecialFunctions"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "1.5.1"
+version = "1.6.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -8,8 +8,8 @@ LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 OpenSpecFun_jll = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
 
 [compat]
-ChainRulesCore = "0.9.44, 0.10"
-ChainRulesTestUtils = "0.6.8, 0.7"
+ChainRulesCore = "0.9.44, 0.10, 1"
+ChainRulesTestUtils = "0.6.8, 0.7, 1"
 LogExpFunctions = "0.2"
 OpenSpecFun_jll = "0.5"
 julia = "1.3"


### PR DESCRIPTION
It's nice that this didn't break anything here.
It would be nice to get this merged relatively quickly, as SpecialFunctions is depended on by many packages and thus will block the ChainRulesCore v1 rollout