### PR TITLE
allow LogExpFunctions 0.3 in compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SpecialFunctions"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "1.6.0"
+version = "1.6.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ OpenSpecFun_jll = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
 [compat]
 ChainRulesCore = "0.9.44, 0.10, 1"
 ChainRulesTestUtils = "0.6.8, 0.7, 1"
-LogExpFunctions = "0.2"
+LogExpFunctions = "0.2, 0.3"
 OpenSpecFun_jll = "0.5"
 julia = "1.3"
 


### PR DESCRIPTION
I think the only breakage is the removal of some exports in https://github.com/JuliaStats/LogExpFunctions.jl/commit/39223ba1daa0244fae1885cd0bcba5a25743349b

cc @devmotion 

Close #333