### PR TITLE
Throw MethodError instead of StackOverflowError for `gamma`, `loggamma`, and `logabsgamma`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SpecialFunctions"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "1.6.2"
+version = "1.6.3"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/SpecialFunctions.jl
+++ b/src/SpecialFunctions.jl
@@ -9,6 +9,7 @@ using IrrationalConstants:
     inv2π,
     invsqrt2,
     invsqrt2π,
+    logtwo,
     logπ,
     log2π
 

--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -234,26 +234,22 @@ function _zeta(s::T, z::T) where {T<:ComplexOrReal{Float64}}
     (z == 1 || z == 0) && return zeta(s)
     s == 2 && return trigamma(z)
 
+    # handle NaN cases
+    if isnan(s) || isnan(z)
+        return T <: Real ? NaN : NaN + NaN*im
+    end
+
     x = real(z)
 
-    # annoying s = Inf or NaN cases:
+    # annoying s = Inf case:
     if !isfinite(s)
-        (isnan(s) || isnan(z)) && return (s*z)^2 # type-stable NaN+Nan*im
         if real(s) == Inf
-            z == 1 && return one(T)
             if x > 1 || (x >= 0.5 ? abs(z) > 1 : abs(z - round(x)) > 1)
                 return zero(T) # distance to poles is > 1
             end
-            x > 0 && imag(z) == 0 && imag(s) == 0 && return T(Inf)
+            x > 0 && isreal(z) && isreal(s) && return T(Inf)
         end
         throw(DomainError(s, "`s` must be finite."))  # nothing clever to return
-    end
-    if isnan(x)
-        if imag(z) == 0 && imag(s) == 0
-            return x
-        else
-            return T(Complex(x,x))
-        end
     end
 
     m = s - 1

--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -573,7 +573,6 @@ export gamma, loggamma, logabsgamma, beta, logbeta, logabsbeta, logfactorial, lo
 gamma(x::Float64)       = nan_dom_err(ccall((:tgamma, libopenlibm), Float64, (Float64,), x), x)
 gamma(x::Float32)       = nan_dom_err(ccall((:tgammaf, libopenlibm), Float32, (Float32,), x), x)
 gamma(x::Float16)       = Float16(gamma(Float32(x)))
-gamma(x::AbstractFloat) = throw(MethodError(gamma, x))
 
 function gamma(x::BigFloat)
     isnan(x) && return x
@@ -615,7 +614,31 @@ the upper incomplete gamma function ``\Gamma(a,z)``.
 - `Complex`: by `exp(loggamma(z))`.
 - `BigFloat`: C library for multiple-precision floating-point [MPFR](https://www.mpfr.org/)
 """
-gamma(x::Number) = gamma(float(x))
+function gamma(x::Number)
+    z = float(x)
+    if typeof(z) === typeof(x)
+        # There is nothing to fallback to
+        throw(MethodError(gamma, x))
+    end
+    return gamma(z)
+end
+
+"""
+    logabsgamma(x)
+
+Compute the logarithm of absolute value of [`gamma`](@ref) for
+[`Real`](@ref) `x`and returns a tuple `(log(abs(gamma(x))), sign(gamma(x)))`.
+
+See also [`loggamma`](@ref).
+"""
+function logabsgamma(x::Real)
+    z = float(x)
+    if typeof(z) === typeof(x)
+        # There is nothing to fallback to
+        throw(MethodError(logabsgamma, x))
+    end
+    return logabsgamma(z)
+end
 
 function logabsgamma(x::Float64)
     signp = Ref{Int32}()
@@ -627,10 +650,7 @@ function logabsgamma(x::Float32)
     y = ccall((:lgammaf_r,libopenlibm),  Float32, (Float32, Ptr{Int32}), x, signp)
     return y, Int(signp[])
 end
-logabsgamma(x::Real) = logabsgamma(float(x))
 logabsgamma(x::Float16) = Float16.(logabsgamma(Float32(x)))
-logabsgamma(x::Integer) = logabsgamma(float(x))
-logabsgamma(x::AbstractFloat) = throw(MethodError(logabsgamma, x))
 
 
 """
@@ -641,16 +661,6 @@ Equivalent to [`loggamma`](@ref) of `x + 1`, but `loggamma` extends this functio
 to non-integer `x`.
 """
 logfactorial(x::Integer) = x < 0 ? throw(DomainError(x, "`x` must be non-negative.")) : loggamma(x + oneunit(x))
-
-"""
-    logabsgamma(x)
-
-Compute the logarithm of absolute value of [`gamma`](@ref) for
-[`Real`](@ref) `x`and returns a tuple `(log(abs(gamma(x))), sign(gamma(x)))`.
-
-See also [`loggamma`](@ref).
-"""
-function logabsgamma end
 
 """
     loggamma(x)
@@ -664,7 +674,14 @@ but `loggamma(x)` may differ from `log(gamma(x))` by an integer multiple of ``2\
 
 See also [`logabsgamma`](@ref) for real `x`.
 """
-loggamma(x::Number) = loggamma(float(x))
+function loggamma(x::Number)
+    z = float(x)
+    if typeof(z) === typeof(x)
+        # There is nothing to fallback to
+        throw(MethodError(loggamma, x))
+    end
+    return loggamma(z)
+end
 
 function loggamma(x::Real)
     (y, s) = logabsgamma(x)

--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -653,7 +653,7 @@ end
 function logabsgamma(x::Float16)
     y, s = logabsgamma(Float32(x))
     return Float16(y), s
-end    
+end
 
 
 """

--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -650,7 +650,10 @@ function logabsgamma(x::Float32)
     y = ccall((:lgammaf_r,libopenlibm),  Float32, (Float32, Ptr{Int32}), x, signp)
     return y, Int(signp[])
 end
-logabsgamma(x::Float16) = Float16.(logabsgamma(Float32(x)))
+function logabsgamma(x::Float16)
+    y, s = logabsgamma(Float32(x))
+    return Float16(y), s
+end    
 
 
 """

--- a/test/gamma.jl
+++ b/test/gamma.jl
@@ -130,6 +130,11 @@
         @test_throws MethodError gamma(NotAFloat())
         @test_throws MethodError logabsgamma(NotAFloat())
         @test_throws MethodError loggamma(NotAFloat())
+
+        # https://github.com/JuliaMath/SpecialFunctions.jl/issues/339
+        # https://github.com/JuliaMath/SpecialFunctions.jl/issues/233
+        @test_throws MethodError gamma(complex(big(1.0)))
+        @test_throws MethodError loggamma(complex(big(1.0)))
     end
 end
 

--- a/test/other_tests.jl
+++ b/test/other_tests.jl
@@ -63,13 +63,13 @@ end
     @test_throws MethodError zeta(big"1.0",2.0)
     @test_throws MethodError zeta(big"1",2.0)
 
-    @test typeof(polygamma(3, 0x2)) == Float64
-    @test typeof(polygamma(big"3", 2f0)) == Float32
-    @test typeof(zeta(1, 2.0)) == Float64
-    @test typeof(zeta(1, 2f0)) == Float64 # BitIntegers result in Float64 returns
-    @test typeof(zeta(2f0, complex(2f0,0f0))) == Complex{Float32}
-    @test typeof(zeta(complex(1,1), 2f0)) == Complex{Float64}
-    @test typeof(zeta(complex(1), 2.0)) == Complex{Float64}
+    @test polygamma(3, 0x2) isa Float64
+    @test polygamma(big"3", 2f0) isa Float32
+    @test zeta(1, 2.0) isa Float64
+    @test zeta(1, 2f0) isa Float32
+    @test zeta(2f0, complex(2f0,0f0)) isa Complex{Float32}
+    @test zeta(complex(1,1), 2f0) isa Complex{Float32}
+    @test zeta(complex(1), 2.0) isa Complex{Float64}
 end
 
 @test sprint(showerror, AmosException(1)) == "AmosException with id 1: input error."


### PR DESCRIPTION
This PR ensures that `MethodError`s are thrown instead of `StackOverflowError`s if `gamma`, `loggamma` and `logabsgamma` are called with arguments for which no fallback exists. Additionally, the dispatches for `gamma` and `logabsgamma` are simplified.

It is a more general alternative to https://github.com/JuliaMath/SpecialFunctions.jl/pull/295.

Fixes https://github.com/JuliaMath/SpecialFunctions.jl/issues/339.
Fixes https://github.com/JuliaMath/SpecialFunctions.jl/issues/233.