### PR TITLE
Handle arguments of 1 in `beta` and `logabsbeta`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SpecialFunctions"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "1.7.0"
+version = "1.7.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -740,13 +740,21 @@ end
 
 Euler integral of the first kind ``\\operatorname{B}(x,y) = \\Gamma(x)\\Gamma(y)/\\Gamma(x+y)``.
 """
-function beta(a::Number, b::Number)
+beta(a::Number, b::Number) = _beta(map(float, promote(a, b))...)
+
+# here `T` is a floating point type but we don't want to restrict the implementation
+# to `AbstractFloat` or `Float64`
+function _beta(a::T, b::T) where {T<:Number}
+    # two special cases
+    a == 1 && return inv(b)
+    b == 1 && return inv(a)
+
     lab, sign = logabsbeta(a, b)
     return sign*exp(lab)
 end
 
 if Base.MPFR.version() >= v"4.0.0"
-    function beta(y::BigFloat, x::BigFloat)
+    function _beta(y::BigFloat, x::BigFloat)
         z = BigFloat()
         ccall((:mpfr_beta, :libmpfr), Int32, (Ref{BigFloat}, Ref{BigFloat}, Ref{BigFloat}, Int32), z, y, x, ROUNDING_MODE[])
         return z
@@ -779,6 +787,17 @@ function logabsbeta(a::T, b::T) where T<:Real
     # ensure that a <= b
     if a > b
         return logabsbeta(b, a)
+    end
+
+    # minimum of arguments is 1
+    if a == 1
+        # b >= a >= 1, so `abs` is not needed and the sign is always 1
+        return -log(b), 1
+    end
+    # maximum of arguments is 1
+    if b == 1
+        sgn = a >= 0 ? 1 : -1
+        return -log(abs(a)), sgn
     end
 
     if a <= 0 && isinteger(a)


### PR DESCRIPTION
This PR adds special handling for arguments of 1 in `beta` and `logabsbeta`. This fixes one of the issues in https://github.com/JuliaStats/StatsFuns.jl/pull/126 (I checked locally that the problem is fixed) but probably it is useful more generally (see https://github.com/JuliaStats/StatsFuns.jl/pull/126#issuecomment-929388271 for a problem in the linked PR).

The additional dispatches of `beta` that are introduced to ensure type stability also fix a bug where e.g. `beta(::BigInt, ::BigFloat)` did not use and differed from the MPFR implementation.