### PR TITLE
Avoid StackOverflowError with erf* functions

### DIFF
--- a/src/erf.jl
+++ b/src/erf.jl
@@ -46,6 +46,33 @@ for f in (:erfcx, :erfi, :dawson)
     end
 end
 
+# MPFR has an open TODO item for this function
+# until then, we use [DLMF 7.12.1](https://dlmf.nist.gov/7.12.1) for the tail
+function _erfcx(x::BigFloat)
+    if x <= (Clong == Int32 ? 0x1p15 : 0x1p30)
+        # any larger gives internal overflow
+        return exp(x^2)*erfc(x)
+    elseif !isfinite(x)
+        return 1/x
+    else
+        # asymptotic series
+        # starts to diverge at iteration i = 2^30 or 2^60
+        # final term will be < Γ(2*i+1)/(2^i * Γ(i+1)) / (2^(i+1))
+        # so good to (lgamma(2*i+1) - lgamma(i+1))/log(2) - 2*i - 1
+        #            ≈ 3.07e10 or 6.75e19 bits
+        # which is larger than the memory of the respective machines
+        ϵ = eps(BigFloat)/4
+        v = 1/(2*x*x)
+        k = 1
+        s = w = -k*v
+        while abs(w) > ϵ
+            k += 2
+            w *= -k*v
+            s += w
+        end
+        return (1+s)/(x*sqrtπ)
+    end
+end
 
 @doc raw"""
     erf(x)
@@ -323,6 +350,25 @@ function _erfinv(x::Float32)
     end
 end
 
+function _erfinv(y::BigFloat)
+    xfloat = erfinv(Float64(y))
+    if isfinite(xfloat)
+        x = BigFloat(xfloat)
+    else
+        # Float64 overflowed, use asymptotic estimate instead
+        # from erfc(x) ≈ exp(-x²)/x√π ≈ y  ⟹  -log(yπ) ≈ x² + log(x) ≈ x²
+        x = copysign(sqrt(-log((1-abs(y))*sqrtπ)), y)
+        isfinite(x) || return x
+    end
+    sqrtπhalf = sqrtπ * big(0.5)
+    tol = 2eps(abs(x))
+    while true # Newton iterations
+        Δx = sqrtπhalf * (erf(x) - y) * exp(x^2)
+        x -= Δx
+        abs(Δx) < tol && break
+    end
+    return x
+end
 
 @doc raw"""
     erfcinv(x)
@@ -424,26 +470,6 @@ function _erfcinv(y::Float32)
     end
 end
 
-function _erfinv(y::BigFloat)
-    xfloat = erfinv(Float64(y))
-    if isfinite(xfloat)
-        x = BigFloat(xfloat)
-    else
-        # Float64 overflowed, use asymptotic estimate instead
-        # from erfc(x) ≈ exp(-x²)/x√π ≈ y  ⟹  -log(yπ) ≈ x² + log(x) ≈ x²
-        x = copysign(sqrt(-log((1-abs(y))*sqrtπ)), y)
-        isfinite(x) || return x
-    end
-    sqrtπhalf = sqrtπ * big(0.5)
-    tol = 2eps(abs(x))
-    while true # Newton iterations
-        Δx = sqrtπhalf * (erf(x) - y) * exp(x^2)
-        x -= Δx
-        abs(Δx) < tol && break
-    end
-    return x
-end
-
 function _erfcinv(y::BigFloat)
     yfloat = Float64(y)
     xfloat = erfcinv(yfloat)
@@ -468,35 +494,6 @@ function _erfcinv(y::BigFloat)
         abs(Δx) < tol && break
     end
     return x
-end
-
-
-# MPFR has an open TODO item for this function
-# until then, we use [DLMF 7.12.1](https://dlmf.nist.gov/7.12.1) for the tail
-function erfcx(x::BigFloat)
-    if x <= (Clong == Int32 ? 0x1p15 : 0x1p30)
-        # any larger gives internal overflow
-        return exp(x^2)*erfc(x)
-    elseif !isfinite(x)
-        return 1/x
-    else
-        # asymptotic series
-        # starts to diverge at iteration i = 2^30 or 2^60
-        # final term will be < Γ(2*i+1)/(2^i * Γ(i+1)) / (2^(i+1))
-        # so good to (lgamma(2*i+1) - lgamma(i+1))/log(2) - 2*i - 1
-        #            ≈ 3.07e10 or 6.75e19 bits
-        # which is larger than the memory of the respective machines
-        ϵ = eps(BigFloat)/4
-        v = 1/(2*x*x)
-        k = 1
-        s = w = -k*v
-        while abs(w) > ϵ
-            k += 2
-            w *= -k*v
-            s += w
-        end
-        return (1+s)/(x*sqrtπ)
-    end
 end
 
 @doc raw"""

--- a/test/erf.jl
+++ b/test/erf.jl
@@ -8,7 +8,7 @@
         @test erfc(Float32(1))  ≈ 0.15729920705028513066 rtol=2*eps(Float32)
         @test erfc(Float64(1))  ≈ 0.15729920705028513066 rtol=2*eps(Float64)
 
-        @test_throws MethodError erfcx(Float16(1))
+        @test erfcx(Float16(1)) ≈ 0.42758357615580700442 rtol=2*eps(Float16)
         @test erfcx(Float32(1)) ≈ 0.42758357615580700442 rtol=2*eps(Float32)
         @test erfcx(Float64(1)) ≈ 0.42758357615580700442 rtol=2*eps(Float64)
 
@@ -38,7 +38,7 @@
         @test logerfcx(Float32(1000)) ≈ -7.48012072190621214066734919080 rtol=2eps(Float32)
         @test logerfcx(Float64(1000)) ≈ -7.48012072190621214066734919080 rtol=2eps(Float64)
 
-        @test_throws MethodError erfi(Float16(1))
+        @test erfi(Float16(1)) ≈ 1.6504257587975428760 rtol=2*eps(Float16)
         @test erfi(Float32(1)) ≈ 1.6504257587975428760 rtol=2*eps(Float32)
         @test erfi(Float64(1)) ≈ 1.6504257587975428760 rtol=2*eps(Float64)
 
@@ -52,7 +52,7 @@
         @test erfcinv(Float32(0.15729920705028513066)) ≈ 1 rtol=2*eps(Float32)
         @test erfcinv(Float64(0.15729920705028513066)) ≈ 1 rtol=2*eps(Float64)
 
-        @test_throws MethodError dawson(Float16(1))
+        @test dawson(Float16(1)) ≈ 0.53807950691276841914 rtol=2*eps(Float16)
         @test dawson(Float32(1)) ≈ 0.53807950691276841914 rtol=2*eps(Float32)
         @test dawson(Float64(1)) ≈ 0.53807950691276841914 rtol=2*eps(Float64)
     end
@@ -66,11 +66,11 @@
         @test erfc(ComplexF32(1+2im)) ≈ 1.5366435657785650340+5.0491437034470346695im
         @test erfc(ComplexF64(1+2im)) ≈ 1.5366435657785650340+5.0491437034470346695im
 
-        @test_throws MethodError erfcx(ComplexF16(1))
+        @test erfcx(ComplexF16(1+2im)) ≈ 0.14023958136627794370-0.22221344017989910261im
         @test erfcx(ComplexF32(1+2im)) ≈ 0.14023958136627794370-0.22221344017989910261im
         @test erfcx(ComplexF64(1+2im)) ≈ 0.14023958136627794370-0.22221344017989910261im
 
-        @test_throws MethodError erfi(ComplexF16(1))
+        @test erfi(ComplexF16(1+2im)) ≈ -0.011259006028815025076+1.0036063427256517509im
         @test erfi(ComplexF32(1+2im)) ≈ -0.011259006028815025076+1.0036063427256517509im
         @test erfi(ComplexF64(1+2im)) ≈ -0.011259006028815025076+1.0036063427256517509im
 
@@ -78,7 +78,7 @@
 
         @test_throws MethodError erfcinv(Complex(1))
 
-        @test_throws MethodError dawson(ComplexF16(1))
+        @test dawson(ComplexF16(1+2im)) ≈ -13.388927316482919244-11.828715103889593303im
         @test dawson(ComplexF32(1+2im)) ≈ -13.388927316482919244-11.828715103889593303im
         @test dawson(ComplexF64(1+2im)) ≈ -13.388927316482919244-11.828715103889593303im
     end
@@ -114,6 +114,18 @@
             @test_throws DomainError erfinv(x)
             @test_throws DomainError erfcinv(1-x)
         end
+    end
+
+    @testset "Other float types" begin
+        struct NotAFloat <: AbstractFloat end
+
+        @test_throws MethodError erf(NotAFloat())
+        @test_throws MethodError erfc(NotAFloat())
+        @test_throws MethodError erfcx(NotAFloat())
+        @test_throws MethodError erfi(NotAFloat())
+        @test_throws MethodError erfinv(NotAFloat())
+        @test_throws MethodError erfcinv(NotAFloat())
+        @test_throws MethodError dawson(NotAFloat())
     end
 
     @testset "inverse" begin


### PR DESCRIPTION
In the same way as https://github.com/JuliaMath/SpecialFunctions.jl/pull/347, this PR avoids StackOverflowErrors and manually thrown MethodErrors by forwarding the erf* functions to an internal function (for which a MethodError is thrown if an implementation is missing).

Fixes https://github.com/JuliaMath/SpecialFunctions.jl/issues/352, with this PR is a MethodError is thrown instead of a StackOverflowError:
```julia
julia> using SpecialFunctions, VectorizationBase

julia> vx = Vec(ntuple(_ -> 10randn(), VectorizationBase.pick_vector_width(Float64))...)
Vec{4, Float64}<-12.340876887492247, 12.779513587757672, -1.5552071156137923, -2.563055489830334>

julia> erf(vx)
ERROR: MethodError: no method matching _erf(::Vec{4, Float64})
Closest candidates are:
  _erf(::Float64) at /home/david/.julia/dev/SpecialFunctions/src/erf.jl:12
  _erf(::Float32) at /home/david/.julia/dev/SpecialFunctions/src/erf.jl:13
  _erf(::Float16) at /home/david/.julia/dev/SpecialFunctions/src/erf.jl:14
  ...
Stacktrace:
 [1] erf(x::Vec{4, Float64})
   @ SpecialFunctions ~/.julia/dev/SpecialFunctions/src/erf.jl:10
 [2] top-level scope
   @ REPL[6]:1
```