### PR TITLE
Use `RealDot.realdot` for more efficient `real(dot(x, y))`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SpecialFunctions"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "1.8.0"
+version = "1.9.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -8,6 +8,7 @@ IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
 LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 OpenLibm_jll = "05823500-19ac-5b8b-9628-191a04bc5112"
 OpenSpecFun_jll = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
+RealDot = "c1ae055f-0cd5-4b69-90a6-9a35b1a98df9"
 
 [compat]
 ChainRulesCore = "0.9.44, 0.10, 1"
@@ -16,6 +17,7 @@ IrrationalConstants = "0.1"
 LogExpFunctions = "0.3"
 OpenLibm_jll = "0.7, 0.8"
 OpenSpecFun_jll = "0.5"
+RealDot = "0.1"
 julia = "1.3"
 
 [extras]

--- a/src/SpecialFunctions.jl
+++ b/src/SpecialFunctions.jl
@@ -15,6 +15,7 @@ using IrrationalConstants:
 
 import ChainRulesCore
 import LogExpFunctions
+import RealDot
 
 using OpenLibm_jll
 using OpenSpecFun_jll

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -216,7 +216,7 @@ function ChainRulesCore.rrule(::typeof(besselix), ν::Number, x::Number)
     function besselix_pullback(ΔΩ)
         ν̄ = ChainRulesCore.@not_implemented(BESSEL_ORDER_INFO)
         a = (besselix(ν - 1, x) + besselix(ν + 1, x)) / 2
-        x̄ = project_x(muladd(conj(a), ΔΩ, - sign(real(x)) * real(conj(Ω) * ΔΩ)))
+        x̄ = project_x(muladd(conj(a), ΔΩ, - sign(real(x)) * RealDot.realdot(Ω, ΔΩ)))
         return ChainRulesCore.NoTangent(), ν̄, x̄
     end
     return Ω, besselix_pullback
@@ -246,7 +246,7 @@ function ChainRulesCore.rrule(::typeof(besseljx), ν::Number, x::Number)
         x̄ = if x isa Real
             project_x(a * ΔΩ)
         else
-            project_x(muladd(conj(a), ΔΩ, - sign(imag(x)) * real(conj(Ω) * ΔΩ) * im))
+            project_x(muladd(conj(a), ΔΩ, - sign(imag(x)) * RealDot.realdot(Ω, ΔΩ) * im))
         end
         return ChainRulesCore.NoTangent(), ν̄, x̄
     end
@@ -277,7 +277,7 @@ function ChainRulesCore.rrule(::typeof(besselyx), ν::Number, x::Number)
         x̄ = if x isa Real
             project_x(a * ΔΩ)
         else
-            project_x(muladd(conj(a), ΔΩ, - sign(imag(x)) * real(conj(Ω) * ΔΩ) * im))
+            project_x(muladd(conj(a), ΔΩ, - sign(imag(x)) * RealDot.realdot(Ω, ΔΩ) * im))
         end
         return ChainRulesCore.NoTangent(), ν̄, x̄
     end


### PR DESCRIPTION
This PR uses `RealDot.realdot` to perform computations of `real(dot(x, y))` more efficiently. [RealDot.jl](https://github.com/JuliaMath/RealDot.jl) is a very lightweight package that only defines `realdot` and only depends on LinearAlgebra: https://github.com/JuliaMath/RealDot.jl/blob/main/src/RealDot.jl