### PR TITLE
Release SpecialFunctions 2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SpecialFunctions"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "1.8.1"
+version = "2.0.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"


### PR DESCRIPTION
This PR bumps the version number to 2.0.0. A breaking release is required due to https://github.com/JuliaMath/SpecialFunctions.jl/pull/297. I agree with [@ararslan's comment](https://github.com/JuliaMath/SpecialFunctions.jl/issues/360#issuecomment-972372301) that as long as there are no other breaking changes that are about to be merged and should be included in this breaking release we can just make a breaking release right away - all bugfixes and non-breaking changes in the master branch are already released.

Fixes https://github.com/JuliaMath/SpecialFunctions.jl/issues/360.