### PR TITLE
Updated Lambert W function implementation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -22,3 +22,35 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+Portions of this code are derived from SciPy and are licensed under
+the Scipy License:
+
+> Copyright (c) 2001, 2002 Enthought, Inc.
+> All rights reserved.
+
+> Copyright (c) 2003-2012 SciPy Developers.
+> All rights reserved.
+
+> Redistribution and use in source and binary forms, with or without
+> modification, are permitted provided that the following conditions are met:
+
+>   a. Redistributions of source code must retain the above copyright notice,
+>      this list of conditions and the following disclaimer.
+>   b. Redistributions in binary form must reproduce the above copyright
+>      notice, this list of conditions and the following disclaimer in the
+>      documentation and/or other materials provided with the distribution.
+>   c. Neither the name of Enthought nor the names of the SciPy Developers
+>      may be used to endorse or promote products derived from this software
+>      without specific prior written permission.
+>
+> THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+> AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+> IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+> ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+> BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+> OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+> SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+> INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+> CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+> ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+> THE POSSIBILITY OF SUCH DAMAGE.

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "2.2.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
 LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 OpenLibm_jll = "05823500-19ac-5b8b-9628-191a04bc5112"
@@ -18,6 +19,7 @@ SpecialFunctionsChainRulesCoreExt = "ChainRulesCore"
 [compat]
 ChainRulesCore = "0.9.44, 0.10, 1"
 ChainRulesTestUtils = "0.6.8, 0.7, 1"
+Compat = "3.7, 4"
 IrrationalConstants = "0.1, 0.2"
 LogExpFunctions = "0.3.2"
 OpenLibm_jll = "0.7, 0.8"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SpecialFunctions.jl
 
 Special mathematical functions in Julia, including Bessel, Hankel, Airy, error, Dawson, exponential (or sine and cosine) integrals,
-eta, zeta, digamma, inverse digamma, trigamma, and polygamma functions.
+eta, zeta, Lambert's W, digamma, inverse digamma, trigamma, and polygamma functions.
 Most of these functions were formerly part of Base in early versions of Julia.
 
 CI (Linux, macOS, FreeBSD, Windows):

--- a/docs/src/functions_list.md
+++ b/docs/src/functions_list.md
@@ -71,5 +71,5 @@ SpecialFunctions.logabsbeta
 SpecialFunctions.logabsbinomial
 SpecialFunctions.lambertw
 SpecialFunctions.lambertwbp
-SpecialFunctions.omega
+SpecialFunctions.LambertW.Ω
 ```

--- a/docs/src/functions_list.md
+++ b/docs/src/functions_list.md
@@ -69,4 +69,7 @@ SpecialFunctions.beta
 SpecialFunctions.logbeta
 SpecialFunctions.logabsbeta
 SpecialFunctions.logabsbinomial
+SpecialFunctions.lambertw
+SpecialFunctions.lambertwbp
+SpecialFunctions.omega
 ```

--- a/docs/src/functions_overview.md
+++ b/docs/src/functions_overview.md
@@ -95,3 +95,9 @@ Here the *Special Functions* are listed according to the structure of [NIST Digi
 |:-------- |:----------- |
 | [`eta(x)`](@ref SpecialFunctions.eta)                         | [Dirichlet eta function](https://en.wikipedia.org/wiki/Dirichlet_eta_function) at `x`                                                                           |
 | [`zeta(x)`](@ref SpecialFunctions.zeta)                       | [Riemann zeta function](https://en.wikipedia.org/wiki/Riemann_zeta_function) at `x`                                                                             |
+
+## [Lambert's W Function](https://dlmf.nist.gov/4.13)
+| Function | Description |
+|:-------- |:----------- |
+| [`lambertw(x, [k=0])`](@ref SpecialFunctions.lambertw)        | [Lambert's W function](https://en.wikipedia.org/wiki/Lambert_W_function) at `x` for `k`-th branch   |
+| [`lambertwbp(x, [k=0])`](@ref SpecialFunctions.lambertwbp)    | Accurate value of ``1 + W_k(-\frac{1}{\mathrm{e}} + x)`` for small `x`                              |

--- a/src/SpecialFunctions.jl
+++ b/src/SpecialFunctions.jl
@@ -77,7 +77,9 @@ export
     expintx,
     sinint,
     cosint,
-    lbinomial
+    lbinomial,
+    lambertw,
+    lambertwbp
 
 include("bessel.jl")
 include("erf.jl")
@@ -90,6 +92,7 @@ include("gamma.jl")
 include("gamma_inc.jl")
 include("betanc.jl")
 include("beta_inc.jl")
+include("lambertw.jl")
 if !isdefined(Base, :get_extension)
     include("../ext/SpecialFunctionsChainRulesCoreExt.jl")
 end

--- a/src/SpecialFunctions.jl
+++ b/src/SpecialFunctions.jl
@@ -81,6 +81,13 @@ export
     lambertw,
     lambertwbp
 
+const omega_const_bf_ = Ref{BigFloat}()
+function __init__()
+    # allocate storage for this BigFloat constant each time this module is loaded
+    omega_const_bf_[] =
+        parse(BigFloat,"0.5671432904097838729999686622103555497538157871865125081351310792230457930866845666932194")
+end
+
 include("bessel.jl")
 include("erf.jl")
 include("ellip.jl")

--- a/src/SpecialFunctions.jl
+++ b/src/SpecialFunctions.jl
@@ -11,7 +11,8 @@ using IrrationalConstants:
     invsqrt2π,
     logtwo,
     logπ,
-    log2π
+    log2π,
+    inve
 
 import LogExpFunctions
 

--- a/src/SpecialFunctions.jl
+++ b/src/SpecialFunctions.jl
@@ -79,14 +79,8 @@ export
     cosint,
     lbinomial,
     lambertw,
-    lambertwbp
-
-const omega_const_bf_ = Ref{BigFloat}()
-function __init__()
-    # allocate storage for this BigFloat constant each time this module is loaded
-    omega_const_bf_[] =
-        parse(BigFloat,"0.5671432904097838729999686622103555497538157871865125081351310792230457930866845666932194")
-end
+    lambertwbp,
+    LambertW
 
 include("bessel.jl")
 include("erf.jl")

--- a/src/SpecialFunctions.jl
+++ b/src/SpecialFunctions.jl
@@ -1,5 +1,7 @@
 module SpecialFunctions
 
+using Compat
+
 using IrrationalConstants:
     twoπ,
     halfπ,

--- a/src/SpecialFunctions.jl
+++ b/src/SpecialFunctions.jl
@@ -13,8 +13,10 @@ using IrrationalConstants:
     invsqrt2π,
     logtwo,
     logπ,
-    log2π,
-    inve
+    log2π
+
+# FIXME temporary until the fate of inve is decided
+Base.@irrational inve 0.367879441171442321595 inv(big(ℯ))
 
 import LogExpFunctions
 

--- a/src/lambertw.jl
+++ b/src/lambertw.jl
@@ -52,7 +52,7 @@ _lambertw(x::Real, k::Integer, maxits::Integer) = _lambertw(x, Val(Int(k)), maxi
 function _lambertw(x::T, ::Val{0}, maxits::Integer) where T<:Real
     isfinite(x) || return x
     one_t = one(T)
-    oneoe = -inv(convert(T, MathConstants.e))  # The branch point
+    oneoe = -T(inve)  # The branch point
     x == oneoe && return -one_t
     oneoe < x || throw(DomainError(x))
     itwo_t = 1 / convert(T, 2)
@@ -68,7 +68,7 @@ end
 
 # Real x, k = -1
 function _lambertw(x::T, ::Val{-1}, maxits::Integer) where T<:Real
-    oneoe = -inv(convert(T, MathConstants.e))
+    oneoe = -T(inve)
     x == oneoe && return -one(T) # W approaches -1 as x -> -1/e from above
     oneoe < x || throw(DomainError(x))  # branch domain exludes x < -1/e
     x == zero(T) && return -convert(T, Inf) # W decreases w/o bound as x -> 0 from below
@@ -86,7 +86,7 @@ _lambertw(z::Complex{<:Integer}, k::Integer, maxits::Integer) = _lambertw(float(
 function _lambertw(z::Complex{T}, k::Integer, maxits::Integer) where T<:Real
     local w::Complex{T}
     pointseven = 7//10
-    if abs(z) <= inv(convert(T, MathConstants.e))
+    if abs(z) <= T(inve)
         if z == 0
             k == 0 && return z
             return complex(-convert(T, Inf), zero(T))
@@ -238,7 +238,7 @@ function lambertwbp_series_length(x::Real)
     x < 5e-2 && return 32
     x < 1e-1 && return 50
     x < 1.9e-1 && return 100
-    x > inv(MathConstants.e) && throw(DomainError(x))  # radius of convergence
+    x > typeof(x)(inve) && throw(DomainError(x))  # radius of convergence
     return 290 # good for x approx .32
 end
 

--- a/src/lambertw.jl
+++ b/src/lambertw.jl
@@ -1,14 +1,130 @@
-import Base: convert
-
-using Compat
-import Compat.MathConstants  # For clarity, we use MathConstants.e for Euler's number
-
 #### Lambert W function ####
 
+"""
+    lambertw(z::Complex{T}, k::V=0, maxits=1000) where {T<:Real, V<:Integer}
+    lambertw(z::T, k::V=0, maxits=1000) where {T<:Real, V<:Integer}
+
+Compute the `k`th branch of the Lambert W function of `z`. If `z` is real, `k` must be
+either `0` or `-1`. For `Real` `z`, the domain of the branch `k = -1` is `[-1/e, 0]` and the
+domain of the branch `k = 0` is `[-1/e, Inf]`. For `Complex` `z`, and all `k`, the domain is
+the complex plane.
+
+```jldoctest
+julia> lambertw(-1/e, -1)
+-1.0
+
+julia> lambertw(-1/e, 0)
+-1.0
+
+julia> lambertw(0, 0)
+0.0
+
+julia> lambertw(0, -1)
+-Inf
+
+julia> lambertw(Complex(-10.0, 3.0), 4)
+-0.9274337508660128 + 26.37693445371142im
+```
+"""
+lambertw(z, k::Integer=0, maxits::Integer=1000) = _lambertw(float(z), k, maxits)
+
+# lambertw(e + 0im, k) is ok for all k
+# Maybe this should return a float. But, this should cause no type instability in any case
+function _lambertw(::typeof(MathConstants.e), k, maxits)
+    k == 0 && return 1
+    throw(DomainError(k))
+end
+_lambertw(x::Irrational, k, maxits) = _lambertw(float(x), k, maxits)
+function _lambertw(x::Union{Integer, Rational}, k, maxits)
+    if k == 0
+        x == 0 && return float(zero(x))
+        x == 1 && return convert(typeof(float(x)), omega) # must be a more efficient way
+    end
+    return _lambertw(float(x), k, maxits)
+end
+
+### Real x
+
+function _lambertw(x::Real, k, maxits)
+    k == 0 && return lambertw_branch_zero(x, maxits)
+    k == -1 && return lambertw_branch_one(x, maxits)
+    throw(DomainError(k, "lambertw: real x must have branch k == 0 or k == -1"))
+end
+
+# Real x, k = 0
+# This appears to be inferrable with T=Float64 and T=BigFloat, including if x=Inf.
+# There is a magic number here. It could be noted, or possibly removed.
+# In particular, the fancy initial condition selection does not seem to help speed.
+function lambertw_branch_zero(x::T, maxits)::T where T<:Real
+    isnan(x) && return(NaN)
+    x == Inf && return Inf # appears to return convert(BigFloat, Inf) for x == BigFloat(Inf)
+    one_t = one(T)
+    oneoe = -one_t / convert(T, MathConstants.e)  # The branch point
+    x == oneoe && return -one_t
+    oneoe <= x || throw(DomainError(x))
+    itwo_t = 1 / convert(T, 2)
+    if x > one_t
+        lx = log(x)
+        llx = log(lx)
+        x0 = lx - llx - log(one_t - llx / lx) * itwo_t
+    else
+        x0 = (567//1000) * x
+    end
+    return lambertw_root_finding(x, x0, maxits)
+end
+
+# Real x, k = -1
+function lambertw_branch_one(x::T, maxits) where T<:Real
+    oneoe = -one(T) / convert(T, MathConstants.e)
+    x == oneoe && return -one(T) # W approaches -1 as x -> -1/e from above
+    oneoe <= x || throw(DomainError(x))  # branch domain exludes x < -1/e
+    x == zero(T) && return -convert(T, Inf) # W decreases w/o bound as x -> 0 from below
+    x < zero(T) || throw(DomainError(x))
+    return lambertw_root_finding(x, log(-x), maxits)
+end
+
+### Complex z
+
+_lambertw(z::Complex{<:Integer}, k, maxits) = _lambertw(float(z), k, maxits)
+# choose initial value inside correct branch for root finding
+function _lambertw(z::Complex{T}, k, maxits) where T<:Real
+    one_t = one(T)
+    local w::Complex{T}
+    pointseven = 7//10
+    if abs(z) <= one_t/convert(T, MathConstants.e)
+        if z == 0
+            k == 0 && return z
+            return complex(-convert(T, Inf), zero(T))
+        end
+        if k == 0
+            w = z
+        elseif k == -1 && imag(z) == 0 && real(z) < 0
+            w = complex(log(-real(z)), 1//10^7) # need offset for z ≈ -1/e.
+        else
+            w = log(z)
+            k != 0 ? w += complex(0, k * 2 * pi) : nothing
+        end
+    elseif k == 0 && imag(z) <= pointseven && abs(z) <= pointseven
+        w = abs(z+ 1//2) < 1//10 ? imag(z) > 0 ? complex(pointseven, pointseven) : complex(pointseven, -pointseven) : z
+    else
+        if real(z) == convert(T, Inf)
+            k == 0 && return z
+            return z + complex(0, 2*k*pi)
+        end
+        real(z) == -convert(T, Inf) && return -z + complex(0, (2*k+1)*pi)
+        w = log(z)
+        k != 0 ? w += complex(0, 2*k*pi) : nothing
+    end
+    return lambertw_root_finding(z, w, maxits)
+end
+
+### root finding, iterative solution
+
 # Use Halley's root-finding method to find
-# x = lambertw(z) with initial point x.
-function _lambertw(z::T, x::T, maxits) where T <: Number
-    two_t = convert(T,2)
+# x = lambertw(z) with initial point x0.
+function lambertw_root_finding(z::T, x0::T, maxits) where T <: Number
+    two_t = convert(T, 2)
+    x = x0
     lastx = x
     lastdiff = zero(T)
     converged::Bool = false
@@ -16,146 +132,27 @@ function _lambertw(z::T, x::T, maxits) where T <: Number
         ex = exp(x)
         xexz = x * ex - z
         x1 = x + 1
-        x -= xexz / (ex * x1 - (x + two_t) * xexz / (two_t * x1 ) )
+        x -= xexz / (ex * x1 - (x + two_t) * xexz / (two_t * x1 ))
         xdiff = abs(lastx - x)
-        if xdiff <= 3*eps(abs(lastx)) || lastdiff == xdiff  # second condition catches two-value cycle
+        if xdiff <= 3 * eps(abs(lastx)) || lastdiff == xdiff  # second condition catches two-value cycle
             converged = true
             break
         end
         lastx = x
         lastdiff = xdiff
     end
-    converged || warn("lambertw with z=", z, " did not converge in ", maxits, " iterations.")
+    converged || @warn("lambertw with z=", z, " did not converge in ", maxits, " iterations.")
     return x
 end
 
-### Real z ###
+### omega constant
 
-# Real x, k = 0
-# This appears to be inferrable with T=Float64 and T=BigFloat, including if x=Inf.
-# The fancy initial condition selection does not seem to help speed, but we leave it for now.
-function lambertwk0(x::T, maxits)::T where T<:AbstractFloat
-    isnan(x) && return(NaN)
-    x == Inf && return Inf # appears to return convert(BigFloat,Inf) for x == BigFloat(Inf)
-    one_t = one(T)
-    oneoe = -one_t/convert(T,MathConstants.e)  # The branch point
-    x == oneoe && return -one_t
-    oneoe <= x || throw(DomainError(x))
-    itwo_t = 1/convert(T,2)
-    if x > one_t
-        lx = log(x)
-        llx = log(lx)
-        x1 = lx - llx - log(one_t - llx/lx) * itwo_t
-    else
-        x1 = (567//1000) * x
-    end
-    return _lambertw(x, x1, maxits)
-end
+const _omega_const = 0.567143290409783872999968662210355
 
-# Real x, k = -1
-function lambertwkm1(x::T, maxits) where T<:Real
-    oneoe = -one(T)/convert(T,MathConstants.e)
-    x == oneoe && return -one(T) # W approaches -1 as x -> -1/e from above
-    oneoe <= x || throw(DomainError(x))  # branch domain exludes x < -1/e
-    x == zero(T) && return -convert(T,Inf) # W decreases w/o bound as x -> 0 from below
-    x < zero(T) || throw(DomainError(x))
-    return _lambertw(x, log(-x), maxits)
-end
-
-"""
-    lambertw(z::Complex{T}, k::V=0, maxits=1000) where {T<:Real, V<:Integer}
-    lambertw(z::T, k::V=0, maxits=1000) where {T<:Real, V<:Integer}
-
-Compute the `k`th branch of the Lambert W function of `z`. If `z` is real, `k` must be
-either `0` or `-1`. For `Real` `z`, the domain of the branch `k = -1` is `[-1/e,0]` and the
-domain of the branch `k = 0` is `[-1/e,Inf]`. For `Complex` `z`, and all `k`, the domain is
-the complex plane. When using root finding to compute `W`, a value for `W` is returned
-with a warning if it has not converged after `maxits` iterations.
-
-```jldoctest
-julia> lambertw(-1/e,-1)
--1.0
-
-julia> lambertw(-1/e,0)
--1.0
-
-julia> lambertw(0,0)
-0.0
-
-julia> lambertw(0,-1)
--Inf
-
-julia> lambertw(Complex(-10.0,3.0), 4)
--0.9274337508660128 + 26.37693445371142im
-```
-
-"""
-lambertw(z, k::Integer=0, maxits::Integer=1000) = lambertw_(z, k, maxits)
-
-function lambertw_(x::Real, k, maxits)
-    k == 0 && return lambertwk0(x, maxits)
-    k == -1 && return lambertwkm1(x, maxits)
-    throw(DomainError(k, "lambertw: real x must have branch k == 0 or k == -1"))
-end
-
-function lambertw_(x::Union{Integer,Rational}, k, maxits)
-    if k == 0
-        x == 0 && return float(zero(x))
-        x == 1 && return convert(typeof(float(x)), omega) # must be a more efficient way
-    end
-    return lambertw_(float(x), k, maxits)
-end
-
-### Complex z ###
-
-# choose initial value inside correct branch for root finding
-function lambertw_(z::Complex{T}, k, maxits) where T<:Real
-    one_t = one(T)
-    local w::Complex{T}
-    pointseven = 7//10
-    if abs(z) <= one_t/convert(T,MathConstants.e)
-        if z == 0
-            k == 0 && return z
-            return complex(-convert(T,Inf),zero(T))
-        end
-        if k == 0
-            w = z
-        elseif k == -1 && imag(z) == 0 && real(z) < 0
-            w = complex(log(-real(z)),1//10^7) # need offset for z ≈ -1/e.
-        else
-            w = log(z)
-            k != 0 ? w += complex(0,k * 2 * pi) : nothing
-        end
-    elseif k == 0 && imag(z) <= pointseven && abs(z) <= pointseven
-        w = abs(z+ 1//2) < 1//10 ? imag(z) > 0 ? complex(pointseven,pointseven) : complex(pointseven,-pointseven) : z
-    else
-        if real(z) == convert(T,Inf)
-            k == 0 && return z
-            return z + complex(0,2*k*pi)
-        end
-        real(z) == -convert(T,Inf) && return -z + complex(0,(2*k+1)*pi)
-        w = log(z)
-        k != 0 ? w += complex(0, 2*k*pi) : nothing
-    end
-    return _lambertw(z, w, maxits)
-end
-
-lambertw_(z::Complex{T}, k, maxits) where T<:Integer = lambertw_(float(z), k, maxits)
-lambertw_(n::Irrational, k, maxits) = lambertw_(float(n), k, maxits)
-
-# lambertw(e + 0im,k) is ok for all k
-# Maybe this should return a float. But, this should cause no type instability in any case
-function lambertw_(::typeof(MathConstants.e), k, maxits)
-    k == 0 && return 1
-    throw(DomainError(k))
-end
-
-### omega constant ###
-
-const omega_const_ = 0.567143290409783872999968662210355
 # The BigFloat `omega_const_bf_` is set via a literal in the function __init__ to prevent a segfault
 
-# maybe compute higher precision. converges very quickly
+# compute omega constant via root finding
+# We could compute higher precision. This converges very quickly.
 function omega_const(::Type{BigFloat})
     precision(BigFloat) <= 256 && return omega_const_bf_[]
     myeps = eps(BigFloat)
@@ -174,6 +171,7 @@ end
 
 The constant defined by `ω exp(ω) = 1`.
 
+# Example
 ```jldoctest
 julia> ω
 ω = 0.5671432904097...
@@ -191,17 +189,12 @@ julia> big(omega)
 const ω = Irrational{:ω}()
 @doc (@doc ω) omega = ω
 
-# The following two lines may be removed when support for v0.6 is dropped
-Base.convert(::Type{AbstractFloat}, o::Irrational{:ω}) = Float64(o)
-Base.convert(::Type{Float16}, o::Irrational{:ω}) = Float16(o)
-Base.convert(::Type{T}, o::Irrational{:ω}) where T <:Number = T(o)
+Base.Float64(::Irrational{:ω}) = _omega_const
+Base.Float32(::Irrational{:ω}) = Float32(_omega_const)
+Base.Float16(::Irrational{:ω}) = Float16(_omega_const)
+Base.BigFloat(::Irrational{:ω}) = omega_const(BigFloat)
 
-Base.Float64(::Irrational{:ω}) = omega_const_  # FIXME: This is very slow. Why ?
-Base.Float32(::Irrational{:ω}) = Float32(omega_const_)
-Base.Float16(::Irrational{:ω}) = Float16(omega_const_)
-Base.BigFloat(o::Irrational{:ω}) = omega_const(BigFloat)
-
-### Expansion about branch point x = -1/e  ###
+### Expansion about branch point x = -1/e
 
 # Refer to the paper "On the Lambert W function". In (4.22)
 # coefficients μ₀ through μ₃ are given explicitly. Recursion relations
@@ -209,83 +202,78 @@ Base.BigFloat(o::Irrational{:ω}) = omega_const(BigFloat)
 # recursion relations.
 
 # (4.23) and (4.24) give zero based coefficients.
-cset(a,i,v) = a[i+1] = v
-cget(a,i) = a[i+1]
+cset(a, i, v) = a[i+1] = v
+cget(a, i) = a[i+1]
 
 # (4.24)
-function compa(k,m,a)
+function compute_a_coeffs(k, m, a)
     sum0 = zero(eltype(m))
-    for j in 2:k-1
-        sum0 += cget(m,j) * cget(m,k+1-j)
+    for j in 2:(k - 1)
+        sum0 += cget(m, j) * cget(m, k + 1 - j)
     end
-    cset(a,k,sum0)
+    cset(a, k, sum0)
     return sum0
 end
 
 # (4.23)
-function compm(k,m,a)
-    kt = convert(eltype(m),k)
-    mk = (kt-1)/(kt+1) *(cget(m,k-2)/2 + cget(a,k-2)/4) -
-        cget(a,k)/2 - cget(m,k-1)/(kt+1)
-    cset(m,k,mk)
+function compute_m_coefficients(k, m, a)
+    kt = convert(eltype(m), k)
+    mk = (kt - 1) / (kt + 1) *(cget(m, k - 2) / 2 + cget(a, k - 2) / 4) -
+        cget(a, k) / 2 - cget(m, k - 1) / (kt + 1)
+    cset(m, k, mk)
     return mk
 end
 
 # We plug the known value μ₂ == -1//3 for (4.22) into (4.23) and
 # solve for α₂. We get α₂ = 0.
-# compute array of coefficients μ in (4.22).
+# Compute array of coefficients μ in (4.22).
 # m[1] is μ₀
-function lamwcoeff(T::DataType, n::Int)
-    # a = @compat Array{T}(undef,n)
-    # m = @compat Array{T}(undef,n)
-    a = zeros(T,n) # We don't need initialization, but Compat is a huge PITA.
-    m = zeros(T,n)
-    cset(a,0,2)  # α₀ literal in paper
-    cset(a,1,-1) # α₁ literal in paper
-    cset(a,2,0)  # α₂ get this by solving (4.23) for alpha_2 with values printed in paper
-    cset(m,0,-1) # μ₀ literal in paper
-    cset(m,1,1)  # μ₁ literal in paper
-    cset(m,2,-1//3) # μ₂ literal in paper, but only in (4.22)
-    for i in 3:n-1  # coeffs are zero indexed
-        compa(i,m,a)
-        compm(i,m,a)
+function compute_branch_point_coeffs(T::DataType, n::Int)
+    a =  Array{T}(undef, n)
+    m =  Array{T}(undef, n)
+    cset(a, 0, 2)  # α₀ literal in paper
+    cset(a, 1, -1) # α₁ literal in paper
+    cset(a, 2, 0)  # α₂ get this by solving (4.23) for alpha_2 with values printed in paper
+    cset(m, 0, -1) # μ₀ literal in paper
+    cset(m, 1, 1)  # μ₁ literal in paper
+    cset(m, 2, -1//3) # μ₂ literal in paper, but only in (4.22)
+    for i in 3:(n - 1)  # coeffs are zero indexed
+        compute_a_coeffs(i, m, a)
+        compute_m_coefficients(i, m, a)
     end
     return m
 end
 
-const LAMWMU_FLOAT64 = lamwcoeff(Float64,500)
+const BRANCH_POINT_COEFFS_FLOAT64 = compute_branch_point_coeffs(Float64, 500)
 
 # Base.Math.@horner requires literal coefficients
-# But, we have an array `p` of computed coefficients
-function horner(x, p::AbstractArray, n)
+# It cannot be used here because we have an array of computed coefficients
+function horner(x, coeffs::AbstractArray, n)
     n += 1
-    ex = p[n]
-    for i = n-1:-1:2
-        ex = :(muladd(t, $ex, $(p[i])))
+    ex = coeffs[n]
+    for i = (n - 1):-1:2
+        ex = :(muladd(t, $ex, $(coeffs[i])))
     end
     ex = :( t * $ex)
     return Expr(:block, :(t = $x), ex)
 end
 
-function mkwser(name, n)
-    iex = horner(:x,LAMWMU_FLOAT64,n)
-    return :(function ($name)(x) $iex  end)
+# write functions that evaluate the branch point series
+# with `num_terms` number of terms.
+for (func_name, num_terms) in (
+    (:wser3, 3), (:wser5, 5), (:wser7, 7), (:wser12, 12),
+    (:wser19, 19), (:wser26, 26), (:wser32, 32),
+    (:wser50, 50), (:wser100, 100), (:wser290, 290))
+    iex = horner(:x, BRANCH_POINT_COEFFS_FLOAT64, num_terms)
+    @eval function ($func_name)(x) $iex end
 end
 
-eval(mkwser(:wser3, 3))
-eval(mkwser(:wser5, 5))
-eval(mkwser(:wser7, 7))
-eval(mkwser(:wser12, 12))
-eval(mkwser(:wser19, 19))
-eval(mkwser(:wser26, 26))
-eval(mkwser(:wser32, 32))
-eval(mkwser(:wser50, 50))
-eval(mkwser(:wser100, 100))
-eval(mkwser(:wser290, 290))
-
 # Converges to Float64 precision
-# We could get finer tuning by separating k=0,-1 branches.
-function wser(p,x)
+# We could get finer tuning by separating k=0, -1 branches.
+# Why is wser5 omitted ?
+# p is the argument to the series which is computed
+# from x before calling `branch_point_series`.
+function branch_point_series(p, x)
     x < 4e-11 && return wser3(p)
     x < 1e-5 && return wser7(p)
     x < 1e-3 && return wser12(p)
@@ -294,12 +282,12 @@ function wser(p,x)
     x < 5e-2 && return wser32(p)
     x < 1e-1 && return wser50(p)
     x < 1.9e-1 && return wser100(p)
-    x > 1/MathConstants.e && throw(DomainError(x))  # radius of convergence
+    x > 1 / MathConstants.e && throw(DomainError(x))  # radius of convergence
     return wser290(p)  # good for x approx .32
 end
 
 # These may need tuning.
-function wser(p::Complex{T},z) where T<:Real
+function branch_point_series(p::Complex{T}, z) where T<:Real
     x = abs(z)
     x < 4e-11 && return wser3(p)
     x < 1e-5 && return wser7(p)
@@ -309,29 +297,31 @@ function wser(p::Complex{T},z) where T<:Real
     x < 5e-2 && return wser32(p)
     x < 1e-1 && return wser50(p)
     x < 1.9e-1 && return wser100(p)
-    x > 1/MathConstants.e && throw(DomainError(x))  # radius of convergence
+    x > 1 / MathConstants.e && throw(DomainError(x))  # radius of convergence
     return wser290(p)
 end
 
-@inline function _lambertw0(x) # 1 + W(-1/e + x)  , k = 0
-    ps = 2*MathConstants.e*x;
-    p = sqrt(ps)
-    return  wser(p,x)
+function _lambertw0(x) # 1 + W(-1/e + x)  , k = 0
+    ps = 2 * MathConstants.e * x
+    series_arg = sqrt(ps)
+    branch_point_series(series_arg, x)
 end
 
-@inline function _lambertwm1(x) # 1 + W(-1/e + x)  , k = -1
-    ps = 2*MathConstants.e*x;
-    p = -sqrt(ps)
-    return wser(p,x)
+function _lambertwm1(x) # 1 + W(-1/e + x)  , k = -1
+    ps = 2 * MathConstants.e * x
+    series_arg = -sqrt(ps)
+    branch_point_series(series_arg, x)
 end
 
 """
-    lambertwbp(z,k=0)
+    lambertwbp(z, k=0)
 
-Compute accurate value of `1 + W(-1/e + z)`, for `abs(z)` in `[0,1/e]` for `k` either `0` or `-1`.
+Compute accurate value of `1 + W(-1/e + z)`, for `abs(z)` in `[0, 1/e]` for `k` either `0` or `-1`.
+This function is faster and more accurate near the branch point `-1/e` between `k=0` and `k=1`.
 The result is accurate to Float64 precision for abs(z) < 0.32.
 If `k=-1` and `imag(z) < 0`, the value on the branch `k=1` is returned.
 
+# Example
 ```jldoctest
 julia> lambertw(-1/e + 1e-18, -1)
 -1.0
@@ -340,7 +330,7 @@ julia> lambertwbp(1e-18, -1)
 -2.331643983409312e-9
 
 # Same result, but 1000 times slower
-julia> convert(Float64,(lambertw(-BigFloat(1)/e + BigFloat(10)^(-18),-1) + 1))
+julia> convert(Float64, (lambertw(-BigFloat(1)/e + BigFloat(10)^(-18), -1) + 1))
 -2.331643983409312e-9
 ```
 
@@ -349,7 +339,7 @@ julia> convert(Float64,(lambertw(-BigFloat(1)/e + BigFloat(10)^(-18),-1) + 1))
     The loss of precision in `lambertw` is analogous to the loss of precision
     in computing the `sqrt(1-x)` for `x` close to `1`.
 """
-function lambertwbp(x::Number,k::Integer)
+function lambertwbp(x::Number, k::Integer)
     k == 0 && return _lambertw0(x)
     k == -1 && return _lambertwm1(x)
     throw(ArgumentError("expansion about branch point only implemented for k = 0 and -1."))

--- a/src/lambertw.jl
+++ b/src/lambertw.jl
@@ -100,7 +100,9 @@ function _lambertw(z::Complex{T}, k::Integer, maxits::Integer) where T<:Real
             k != 0 ? w += complex(0, k * 2 * pi) : nothing
         end
     elseif k == 0 && imag(z) <= pointseven && abs(z) <= pointseven
-        w = abs(z+ 1//2) < 1//10 ? imag(z) > 0 ? complex(pointseven, pointseven) : complex(pointseven, -pointseven) : z
+        w = abs(z+ 1//2) < 1//10 ? imag(z) > 0 ?
+                complex(pointseven, pointseven) :
+                complex(pointseven, -pointseven) : z
     else
         if real(z) == convert(T, Inf)
             k == 0 && return z
@@ -118,16 +120,15 @@ end
 # Use Halley's root-finding method to find
 # x = lambertw(z) with initial point x0.
 function lambertw_root_finding(z::T, x0::T, maxits::Integer) where T <: Number
-    two_t = convert(T, 2)
     x = x0
     lastx = x
     lastdiff = zero(real(T))
     converged = false
-    for i in 1:maxits
+    for _ in 1:maxits
         ex = exp(x)
         xexz = x * ex - z
         x1 = x + 1
-        x -= xexz / (ex * x1 - (x + two_t) * xexz / (two_t * x1 ))
+        x -= xexz / (ex * x1 - (x + 2) * xexz / (2 * x1))
         xdiff = abs(lastx - x)
         if xdiff <= 3 * eps(lastdiff) || lastdiff == xdiff  # second condition catches two-value cycle
             converged = true
@@ -136,7 +137,7 @@ function lambertw_root_finding(z::T, x0::T, maxits::Integer) where T <: Number
         lastx = x
         lastdiff = xdiff
     end
-    converged || @warn("lambertw with z=", z, " did not converge in ", maxits, " iterations.")
+    converged || @warn("lambertw(", z, ") did not converge in ", maxits, " iterations.")
     return x
 end
 

--- a/src/lambertw.jl
+++ b/src/lambertw.jl
@@ -1,0 +1,386 @@
+import Base: convert
+#export lambertw, lambertwbp
+using Compat
+
+const euler =
+if isdefined(Base, :MathConstants)
+    Base.MathConstants.e
+else
+    e
+end
+
+const omega_const_bf_ = Ref{BigFloat}()
+
+function __init__()
+    omega_const_bf_[] =
+        parse(BigFloat,"0.5671432904097838729999686622103555497538157871865125081351310792230457930866845666932194")
+end
+
+#### Lambert W function ####
+
+const LAMBERTW_USE_NAN = false
+
+macro baddomain(v)
+    if LAMBERTW_USE_NAN
+        return :(return(NaN))
+    else
+        return esc(:(throw(DomainError($v))))
+    end
+end
+
+# Use Halley's root-finding method to find x = lambertw(z) with
+# initial point x.
+function _lambertw(z::T, x::T) where T <: Number
+    two_t = convert(T,2)
+    lastx = x
+    lastdiff = zero(T)
+    for i in 1:100
+        ex = exp(x)
+        xexz = x * ex - z
+        x1 = x + 1
+        x = x - xexz / (ex * x1 - (x + two_t) * xexz / (two_t * x1 ) )
+        xdiff = abs(lastx - x)
+        xdiff <= 2*eps(abs(lastx)) && break
+        lastdiff == diff && break
+        lastx = x
+        lastdiff = xdiff
+    end
+    x
+end
+
+### Real z ###
+
+# Real x, k = 0
+
+# The fancy initial condition selection does not seem to help speed, but we leave it for now.
+function lambertwk0(x::T)::T where T<:AbstractFloat
+    x == Inf && return Inf
+    one_t = one(T)
+    oneoe = -one_t/convert(T,euler)
+    x == oneoe && return -one_t
+    itwo_t = 1/convert(T,2)
+    oneoe <= x || @baddomain(x)
+    if x > one_t
+        lx = log(x)
+        llx = log(lx)
+        x1 = lx - llx - log(one_t - llx/lx) * itwo_t
+    else
+        x1 = (567//1000) * x
+    end
+    _lambertw(x,x1)
+end
+
+# Real x, k = -1
+function _lambertwkm1(x::T) where T<:Real
+    oneoe = -one(T)/convert(T,euler)
+    x == oneoe && return -one(T)
+    oneoe <= x || @baddomain(x)
+    x == zero(T) && return -convert(T,Inf)
+    x < zero(T) || @baddomain(x)
+    _lambertw(x,log(-x))
+end
+
+
+"""
+    lambertw(z::Complex{T}, k::V=0) where {T<:Real, V<:Integer}
+    lambertw(z::T, k::V=0) where {T<:Real, V<:Integer}
+
+Compute the `k`th branch of the Lambert W function of `z`. If `z` is real, `k` must be
+either `0` or `-1`. For `Real` `z`, the domain of the branch `k = -1` is `[-1/e,0]` and the
+domain of the branch `k = 0` is `[-1/e,Inf]`. For `Complex` `z`, and all `k`, the domain is
+the complex plane.
+
+```jldoctest
+julia> lambertw(-1/e,-1)
+-1.0
+
+julia> lambertw(-1/e,0)
+-1.0
+
+julia> lambertw(0,0)
+0.0
+
+julia> lambertw(0,-1)
+-Inf
+
+julia> lambertw(Complex(-10.0,3.0), 4)
+-0.9274337508660128 + 26.37693445371142im
+```
+
+!!! note
+    The constant `LAMBERTW_USE_NAN` at the top of the source file controls whether arguments
+    outside the domain throw `DomainError` or return `NaN`. The default is `DomainError`.
+"""
+function lambertw(x::Real, k::Integer)
+    k == 0 && return lambertwk0(x)
+    k == -1 && return _lambertwkm1(x)
+    @baddomain(k)  # more informative message like below ?
+#    error("lambertw: real x must have k == 0 or k == -1")
+end
+
+function lambertw(x::Union{Integer,Rational}, k::Integer)
+    if k == 0
+        x == 0 && return float(zero(x))
+        x == 1 && return convert(typeof(float(x)),omega) # must be more efficient way
+    end
+    lambertw(float(x),k)
+end
+
+### Complex z ###
+
+# choose initial value inside correct branch for root finding
+function lambertw(z::Complex{T}, k::Integer) where T<:Real
+    one_t = one(T)
+    local w::Complex{T}
+    pointseven = 7//10
+    if abs(z) <= one_t/convert(T,euler)
+        if z == 0
+            k == 0 && return z
+            return complex(-convert(T,Inf),zero(T))
+        end
+        if k == 0
+            w = z
+        elseif k == -1 && imag(z) == 0 && real(z) < 0
+            w = complex(log(-real(z)),1//10^7) # need offset for z ≈ -1/e.
+        else
+            w = log(z)
+            k != 0 ? w += complex(0,k * 2 * pi) : nothing
+        end
+    elseif k == 0 && imag(z) <= pointseven && abs(z) <= pointseven
+        w = abs(z+ 1//2) < 1//10 ? imag(z) > 0 ? complex(pointseven,pointseven) : complex(pointseven,-pointseven) : z
+    else
+        if real(z) == convert(T,Inf)
+            k == 0 && return z
+            return z + complex(0,2*k*pi)
+        end
+        real(z) == -convert(T,Inf) && return -z + complex(0,(2*k+1)*pi)
+        w = log(z)
+        k != 0 ? w += complex(0, 2*k*pi) : nothing
+    end
+    _lambertw(z,w)
+end
+
+lambertw(z::Complex{T}, k::Integer) where T<:Integer = lambertw(float(z),k)
+
+# lambertw(e + 0im,k) is ok for all k
+#function lambertw(::Irrational{:e}, k::T) where T<:Integer
+function lambertw(::typeof(euler), k::T) where T<:Integer
+    k == 0 && return 1
+    @baddomain(k)
+end
+
+# Maybe this should return a float
+lambertw(::typeof(euler)) = 1
+#lambertw(::Irrational{:e}) = 1
+
+#lambertw{T<:Number}(x::T) = lambertw(x,0)
+lambertw(x::Number) = lambertw(x,0)
+
+lambertw(n::Irrational, args::Integer...) = lambertw(float(n),args...)
+
+### omega constant ###
+
+const omega_const_ = 0.567143290409783872999968662210355
+# The BigFloat `omega_const_bf_` is set via a literal in the function __init__ to prevent a segfault
+
+# maybe compute higher precision. converges very quickly
+function omega_const(::Type{BigFloat})
+  @compat  precision(BigFloat) <= 256 && return omega_const_bf_[]
+    myeps = eps(BigFloat)
+    oc = omega_const_bf_[]
+    for i in 1:100
+        nextoc = (1 + oc) / (1 + exp(oc))
+        abs(oc - nextoc) <= myeps && break
+        oc = nextoc
+    end
+    return oc
+end
+
+"""
+    omega
+    ω
+
+A constant defined by `ω exp(ω) = 1`.
+
+```jldoctest
+julia> ω
+ω = 0.5671432904097...
+
+julia> omega
+ω = 0.5671432904097...
+
+julia> ω * exp(ω)
+1.0
+
+julia> big(omega)
+5.67143290409783872999968662210355549753815787186512508135131079223045793086683e-01
+```
+"""
+const ω = Irrational{:ω}()
+@doc (@doc ω) omega = ω
+
+# The following three lines may be removed when support for v0.6 is dropped
+Base.convert(::Type{AbstractFloat}, o::Irrational{:ω}) = Float64(o)
+Base.convert(::Type{Float16}, o::Irrational{:ω}) = Float16(o)
+Base.convert(::Type{T}, o::Irrational{:ω}) where T <:Number = T(o)
+
+Base.Float64(::Irrational{:ω}) = omega_const_  # FIXME: This is very slow. Why ?
+Base.Float32(::Irrational{:ω}) = Float32(omega_const_)
+Base.Float16(::Irrational{:ω}) = Float16(omega_const_)
+Base.BigFloat(o::Irrational{:ω}) = omega_const(BigFloat)
+
+### Expansion about branch point x = -1/e  ###
+
+# Refer to the paper "On the Lambert W function". In (4.22)
+# coefficients μ₀ through μ₃ are given explicitly. Recursion relations
+# (4.23) and (4.24) for all μ are also given. This code implements the
+# recursion relations.
+
+# (4.23) and (4.24) give zero based coefficients
+cset(a,i,v) = a[i+1] = v
+cget(a,i) = a[i+1]
+
+# (4.24)
+function compa(k,m,a)
+    sum0 = zero(eltype(m))
+    for j in 2:k-1
+        sum0 += cget(m,j) * cget(m,k+1-j)
+    end
+    cset(a,k,sum0)
+    sum0
+end
+
+# (4.23)
+function compm(k,m,a)
+    kt = convert(eltype(m),k)
+    mk = (kt-1)/(kt+1) *(cget(m,k-2)/2 + cget(a,k-2)/4) -
+        cget(a,k)/2 - cget(m,k-1)/(kt+1)
+    cset(m,k,mk)
+    mk
+end
+
+# We plug the known value μ₂ == -1//3 for (4.22) into (4.23) and
+# solve for α₂. We get α₂ = 0.
+# compute array of coefficients μ in (4.22).
+# m[1] is μ₀
+function lamwcoeff(T::DataType, n::Int)
+    # a = @compat Array{T}(undef,n)
+    # m = @compat Array{T}(undef,n)
+    a = zeros(T,n) # We don't need initialization, but Compat is a huge PITA.
+    m = zeros(T,n)
+    cset(a,0,2)  # α₀ literal in paper
+    cset(a,1,-1) # α₁ literal in paper
+    cset(a,2,0)  # α₂ get this by solving (4.23) for alpha_2 with values printed in paper
+    cset(m,0,-1) # μ₀ literal in paper
+    cset(m,1,1)  # μ₁ literal in paper
+    cset(m,2,-1//3) # μ₂ literal in paper, but only in (4.22)
+    for i in 3:n-1  # coeffs are zero indexed
+        compa(i,m,a)
+        compm(i,m,a)
+    end
+    return m
+end
+
+const LAMWMU_FLOAT64 = lamwcoeff(Float64,500)
+
+function horner(x, p::AbstractArray,n)
+    n += 1
+    ex = p[n]
+    for i = n-1:-1:2
+        ex = :($(p[i]) + t * $ex)
+    end
+    ex = :( t * $ex)
+    Expr(:block, :(t = $x), ex)
+end
+
+function mkwser(name, n)
+    iex = horner(:x,LAMWMU_FLOAT64,n)
+    :(function ($name)(x) $iex  end)
+end
+
+eval(mkwser(:wser3, 3))
+eval(mkwser(:wser5, 5))
+eval(mkwser(:wser7, 7))
+eval(mkwser(:wser12, 12))
+eval(mkwser(:wser19, 19))
+eval(mkwser(:wser26, 26))
+eval(mkwser(:wser32, 32))
+eval(mkwser(:wser50, 50))
+eval(mkwser(:wser100, 100))
+eval(mkwser(:wser290, 290))
+
+# Converges to Float64 precision
+# We could get finer tuning by separating k=0,-1 branches.
+function wser(p,x)
+    x < 4e-11 && return wser3(p)
+    x < 1e-5 && return wser7(p)
+    x < 1e-3 && return wser12(p)
+    x < 1e-2 && return wser19(p)
+    x < 3e-2 && return wser26(p)
+    x < 5e-2 && return wser32(p)
+    x < 1e-1 && return wser50(p)
+    x < 1.9e-1 && return wser100(p)
+    x > 1/euler && @baddomain(x)  # radius of convergence
+    return wser290(p)  # good for x approx .32
+end
+
+# These may need tuning.
+function wser(p::Complex{T},z) where T<:Real
+    x = abs(z)
+    x < 4e-11 && return wser3(p)
+    x < 1e-5 && return wser7(p)
+    x < 1e-3 && return wser12(p)
+    x < 1e-2 && return wser19(p)
+    x < 3e-2 && return wser26(p)
+    x < 5e-2 && return wser32(p)
+    x < 1e-1 && return wser50(p)
+    x < 1.9e-1 && return wser100(p)
+    x > 1/euler && @baddomain(x)  # radius of convergence
+    return wser290(p)
+end
+
+@inline function _lambertw0(x) # 1 + W(-1/e + x)  , k = 0
+    ps = 2*euler*x;
+    p = sqrt(ps)
+    wser(p,x)
+end
+
+@inline function _lambertwm1(x) # 1 + W(-1/e + x)  , k = -1
+    ps = 2*euler*x;
+    p = -sqrt(ps)
+    wser(p,x)
+end
+
+"""
+    lambertwbp(z,k=0)
+
+Accurate value of `1 + W(-1/e + z)`, for `abs(z)` in `[0,1/e]` for `k` either `0` or `-1`.
+Accurate to Float64 precision for abs(z) < 0.32.
+If `k=-1` and `imag(z) < 0`, the value on the branch `k=1` is returned. `lambertwbp` is vectorized.
+
+```jldoctest
+julia> lambertw(-1/e + 1e-18, -1)
+-1.0
+
+julia> lambertwbp(1e-18, -1)
+-2.331643983409312e-9
+
+# Same result, but 1000 times slower
+julia> convert(Float64,(lambertw(-BigFloat(1)/e + BigFloat(10)^(-18),-1) + 1))
+-2.331643983409312e-9
+```
+
+!!! note
+    `lambertwbp` uses a series expansion about the branch point `z=-1/e` to avoid loss of precision.
+    The loss of precision in `lambertw` is analogous to the loss of precision
+    in computing the `sqrt(1-x)` for `x` close to `1`.
+"""
+function lambertwbp(x::Number,k::Integer)
+    k == 0 && return _lambertw0(x)
+    k == -1 && return _lambertwm1(x)
+    error("expansion about branch point only implemented for k = 0 and -1")
+end
+
+lambertwbp(x::Number) = _lambertw0(x)
+
+nothing

--- a/src/lambertw.jl
+++ b/src/lambertw.jl
@@ -8,11 +8,11 @@ either `0` or `-1`. For `Real` `z`, the domain of the branch `k = -1` is `[-1/e,
 domain of the branch `k = 0` is `[-1/e, Inf]`. For `Complex` `z`, and all `k`, the domain is
 the complex plane.
 
-```jldoctest
-julia> lambertw(-1/e, -1)
+```jldoctest; setup=:(using SpecialFunctions)
+julia> lambertw(-1/ℯ, -1)
 -1.0
 
-julia> lambertw(-1/e, 0)
+julia> lambertw(-1/ℯ, 0)
 -1.0
 
 julia> lambertw(0, 0)
@@ -268,20 +268,19 @@ The result is accurate to Float64 precision for abs(z) < 0.32.
 If `k=-1` and `imag(z) < 0`, the value on the branch `k=1` is returned.
 
 # Example
-```jldoctest
-julia> lambertw(-1/e + 1e-18, -1)
+```jldoctest; setup=:(using SpecialFunctions)
+julia> lambertw(-1/ℯ + 1e-18, -1)
 -1.0
 
 julia> lambertwbp(1e-18, -1)
 -2.331643983409312e-9
 
-# Same result, but 1000 times slower
-julia> convert(Float64, (lambertw(-BigFloat(1)/e + BigFloat(10)^(-18), -1) + 1))
+julia> convert(Float64, (lambertw(-big(1)/ℯ + big(10)^(-18), -1) + 1)) # Same result, but 1000 times slower
 -2.331643983409312e-9
 ```
 
 !!! note
-    `lambertwbp` uses a series expansion about the branch point `z=-1/e` to avoid loss of precision.
+    `lambertwbp` uses a series expansion about the branch point `z=-1/ℯ` to avoid loss of precision.
     The loss of precision in `lambertw` is analogous to the loss of precision
     in computing the `sqrt(1-x)` for `x` close to `1`.
 """

--- a/src/lambertw.jl
+++ b/src/lambertw.jl
@@ -52,16 +52,14 @@ function _lambertw(x::Real, k, maxits)
 end
 
 # Real x, k = 0
-# This appears to be inferrable with T=Float64 and T=BigFloat, including if x=Inf.
 # There is a magic number here. It could be noted, or possibly removed.
 # In particular, the fancy initial condition selection does not seem to help speed.
-function lambertw_branch_zero(x::T, maxits)::T where T<:Real
-    isnan(x) && return(NaN)
-    x == Inf && return Inf # appears to return convert(BigFloat, Inf) for x == BigFloat(Inf)
+function lambertw_branch_zero(x::T, maxits) where T<:Real
+    isfinite(x) || return x
     one_t = one(T)
     oneoe = -one_t / convert(T, MathConstants.e)  # The branch point
     x == oneoe && return -one_t
-    oneoe <= x || throw(DomainError(x))
+    oneoe < x || throw(DomainError(x))
     itwo_t = 1 / convert(T, 2)
     if x > one_t
         lx = log(x)
@@ -77,7 +75,7 @@ end
 function lambertw_branch_one(x::T, maxits) where T<:Real
     oneoe = -one(T) / convert(T, MathConstants.e)
     x == oneoe && return -one(T) # W approaches -1 as x -> -1/e from above
-    oneoe <= x || throw(DomainError(x))  # branch domain exludes x < -1/e
+    oneoe < x || throw(DomainError(x))  # branch domain exludes x < -1/e
     x == zero(T) && return -convert(T, Inf) # W decreases w/o bound as x -> 0 from below
     x < zero(T) || throw(DomainError(x))
     return lambertw_root_finding(x, log(-x), maxits)

--- a/src/lambertw.jl
+++ b/src/lambertw.jl
@@ -137,7 +137,7 @@ function lambertw_root_finding(z::T, x0::T, maxits::Integer) where T <: Number
         lastx = x
         lastdiff = xdiff
     end
-    converged || @warn("lambertw(", z, ") did not converge in ", maxits, " iterations.")
+    converged || @warn "lambertw($z) did not converge in $maxits iterations."
     return x
 end
 

--- a/src/lambertw.jl
+++ b/src/lambertw.jl
@@ -126,15 +126,15 @@ function lambertw_root_finding(z::T, x0::T, maxits) where T <: Number
     two_t = convert(T, 2)
     x = x0
     lastx = x
-    lastdiff = zero(T)
-    converged::Bool = false
+    lastdiff = zero(real(T))
+    converged = false
     for i in 1:maxits
         ex = exp(x)
         xexz = x * ex - z
         x1 = x + 1
         x -= xexz / (ex * x1 - (x + two_t) * xexz / (two_t * x1 ))
         xdiff = abs(lastx - x)
-        if xdiff <= 3 * eps(abs(lastx)) || lastdiff == xdiff  # second condition catches two-value cycle
+        if xdiff <= 3 * eps(lastdiff) || lastdiff == xdiff  # second condition catches two-value cycle
             converged = true
             break
         end

--- a/src/lambertw.jl
+++ b/src/lambertw.jl
@@ -1,9 +1,9 @@
 #### Lambert W function ####
 
 """
-    lambertw(z::Number, k::Integer=0, maxits=1000)
+    lambertw(z::Number, k::Integer=0; [maxiter=1000])
 
-Compute the `k`th branch of the Lambert W function of `z`. If `z` is real, `k` must be
+Compute the `k`th branch of the [Lambert W function](https://en.wikipedia.org/wiki/Lambert_W_function) of `z`. If `z` is real, `k` must be
 either `0` or `-1`. For `Real` `z`, the domain of the branch `k = -1` is `[-1/e, 0]` and the
 domain of the branch `k = 0` is `[-1/e, Inf]`. For `Complex` `z`, and all `k`, the domain is
 the complex plane.
@@ -25,7 +25,7 @@ julia> lambertw(Complex(-10.0, 3.0), 4)
 -0.9274337508660128 + 26.37693445371142im
 ```
 """
-lambertw(z::Number, k::Integer=0, maxits::Integer=1000) = _lambertw(float(z), k, maxits)
+lambertw(z::Number, k::Integer=0; maxiter::Integer=1000) = _lambertw(z, k, maxiter)
 
 # lambertw(e + 0im, k) is ok for all k
 # Maybe this should return a float. But, this should cause no type instability in any case

--- a/src/lambertw.jl
+++ b/src/lambertw.jl
@@ -57,7 +57,7 @@ end
 function lambertw_branch_zero(x::T, maxits) where T<:Real
     isfinite(x) || return x
     one_t = one(T)
-    oneoe = -one_t / convert(T, MathConstants.e)  # The branch point
+    oneoe = -inv(convert(T, MathConstants.e))  # The branch point
     x == oneoe && return -one_t
     oneoe < x || throw(DomainError(x))
     itwo_t = 1 / convert(T, 2)
@@ -73,7 +73,7 @@ end
 
 # Real x, k = -1
 function lambertw_branch_one(x::T, maxits) where T<:Real
-    oneoe = -one(T) / convert(T, MathConstants.e)
+    oneoe = -inv(convert(T, MathConstants.e))
     x == oneoe && return -one(T) # W approaches -1 as x -> -1/e from above
     oneoe < x || throw(DomainError(x))  # branch domain exludes x < -1/e
     x == zero(T) && return -convert(T, Inf) # W decreases w/o bound as x -> 0 from below
@@ -89,7 +89,7 @@ function _lambertw(z::Complex{T}, k, maxits) where T<:Real
     one_t = one(T)
     local w::Complex{T}
     pointseven = 7//10
-    if abs(z) <= one_t/convert(T, MathConstants.e)
+    if abs(z) <= inv(convert(T, MathConstants.e))
         if z == 0
             k == 0 && return z
             return complex(-convert(T, Inf), zero(T))

--- a/test/lambertw.jl
+++ b/test/lambertw.jl
@@ -131,7 +131,7 @@ end
             z = BigFloat(10)^(-12)
             for _ in 1:300
                 @test lambertwbp(Float64(z)) ≈ 1 + lambertw(z - big(inve)) atol=5e-16
-                @test lambertwbp(Float64(z), -1) ≈ 1 + lambertw(z - big(inve), -1) atol=5e-15
+                @test lambertwbp(Float64(z), -1) ≈ 1 + lambertw(z - big(inve), -1) atol=1e-15
 
                 z *= 1.1
                 if z > 0.23 break end
@@ -142,5 +142,5 @@ end
     # test the expansion about branch point for k=-1,
     # by comparing to exact BigFloat calculation.
     @test @inferred(lambertwbp(1e-20, -1)) ≈ 1 + lambertw(-big(inve) + BigFloat(10)^(-20), -1) atol=1e-16
-    @test @inferred(lambertwbp(Complex(.01, .01), -1)) ≈ Complex(-0.2755038208041206, -0.1277888928494641) atol=1e-14
+    @test @inferred(lambertwbp(Complex(.01, .01), -1)) ≈ Complex(-0.27550382080412062443536, -0.12778889284946406573511) atol=1e-16
 end

--- a/test/lambertw.jl
+++ b/test/lambertw.jl
@@ -77,6 +77,12 @@ end
 @test lambertw(complex(-3.0, -4.0), 1) ≈ Complex(0.5887666813694675, 2.7118802109452247) atol=1e-14
 @test lambertw(complex(.3, .3)) ≈ Complex(0.26763519642648767, 0.1837481231767825)
 
+# test maxiter keyword and convergence warning
+@test_logs (:warn, "lambertw(-0.2) did not converge in 3 iterations.") @inferred(lambertw(-0.2, -1, maxiter=3))
+@test lambertw(-0.2, -1, maxiter=5) == lambertw(-0.2, -1)
+@test_logs (:warn, "lambertw(0.3 + 0.3im) did not converge in 3 iterations.") @inferred(lambertw(complex(.3, .3), maxiter=3))
+@test lambertw(complex(.3, .3), maxiter=5) == lambertw(complex(.3, .3))
+
 # bug fix
 # The routine will start at -1/e + eps * im, rather than -1/e + 0im,
 # otherwise root finding will fail

--- a/test/lambertw.jl
+++ b/test/lambertw.jl
@@ -34,15 +34,15 @@ using IrrationalConstants
 
 ### infinite args or return values
 
-@test lambertw(0, -1) == lambertw(0.0, -1) == -Inf
-@test lambertw(Inf, 0) == Inf
+@test @inferred(lambertw(0, -1)) == @inferred(lambertw(0.0, -1)) == -Inf
+@test @inferred(lambertw(Inf, 0)) == Inf
 @test @inferred(lambertw(complex(Inf, 1), 0)) == complex(Inf, 1)
-@test lambertw(complex(Inf, 0), 1) == complex(Inf, 2pi)
-@test lambertw(complex(-Inf, 0), 1) == complex(Inf, 3pi)
+@test @inferred(lambertw(complex(Inf, 0), 1)) == complex(Inf, 2pi)
+@test @inferred(lambertw(complex(-Inf, 0), 1)) == complex(Inf, 3pi)
 @test @inferred(lambertw(complex(0.0, 0.0), -1)) == complex(-Inf, 0.0)
 
-## default branch is  k = 0
-@test lambertw(1.0) == lambertw(1.0, 0)
+## default branch is k = 0
+@test @inferred(lambertw(1.0)) == @inferred(lambertw(1.0, 0))
 
 ## BigInt args return BigFloats
 @test @inferred(lambertw(BigInt(0))) isa BigFloat

--- a/test/lambertw.jl
+++ b/test/lambertw.jl
@@ -3,21 +3,21 @@
 @test_throws DomainError lambertw(-2.0, 0)
 @test_throws DomainError lambertw(-2.0, -1)
 @test_throws DomainError lambertw(-2.0, 1)
-@test isnan(lambertw(NaN))
+@test isnan(@inferred(lambertw(NaN)))
 
 ## math constant e
 @test_throws DomainError lambertw(MathConstants.e, 1)
 @test_throws DomainError lambertw(MathConstants.e, -1)
 
 ## integer arguments return floating point types
-@test lambertw(0) isa AbstractFloat
-@test lambertw(0) == 0
+@test @inferred(lambertw(0)) isa AbstractFloat
+@test @inferred(lambertw(0)) == 0
 
 ### math constant, MathConstants.e e
 
 # could return math const e, but this would break type stability
-@test lambertw(1) isa AbstractFloat
-@test lambertw(MathConstants.e, 0) == 1
+@test @inferred(lambertw(1)) isa AbstractFloat
+@test @inferred(lambertw(MathConstants.e, 0)) == 1
 
 ## value at branch point where real branches meet
 @test lambertw(-inv(MathConstants.e), 0) == lambertw(-inv(MathConstants.e), -1) == -1
@@ -25,24 +25,24 @@
 
 ## convert irrationals to float
 
-@test isapprox(lambertw(pi), 1.0736581947961492)
-@test isapprox(lambertw(pi, 0), 1.0736581947961492)
+@test isapprox(@inferred(lambertw(pi)), 1.0736581947961492)
+@test isapprox(@inferred(lambertw(pi, 0)), 1.0736581947961492)
 
 ### infinite args or return values
 
 @test lambertw(0, -1) == lambertw(0.0, -1) == -Inf
 @test lambertw(Inf, 0) == Inf
-@test lambertw(complex(Inf, 1), 0) == complex(Inf, 1)
+@test @inferred(lambertw(complex(Inf, 1), 0)) == complex(Inf, 1)
 @test lambertw(complex(Inf, 0), 1) == complex(Inf, 2pi)
 @test lambertw(complex(-Inf, 0), 1) == complex(Inf, 3pi)
-@test lambertw(complex(0.0, 0.0), -1) == complex(-Inf, 0.0)
+@test @inferred(lambertw(complex(0.0, 0.0), -1)) == complex(-Inf, 0.0)
 
 ## default branch is  k = 0
 @test lambertw(1.0) == lambertw(1.0, 0)
 
 ## BigInt args return BigFloats
-@test typeof(lambertw(BigInt(0))) == BigFloat
-@test typeof(lambertw(BigInt(3))) == BigFloat
+@test @inferred(lambertw(BigInt(0))) isa BigFloat
+@test @inferred(lambertw(BigInt(3))) isa BigFloat
 
 ## Any Integer type allowed for second argument
 @test lambertw(-0.2, -1) == lambertw(-0.2, BigInt(-1))
@@ -145,8 +145,8 @@ end
 
 # test the expansion about branch point for k=-1,
 # by comparing to exact BigFloat calculation.
-@test lambertwbp(1e-20, -1) - 1 - lambertw(-inv(big(MathConstants.e)) + BigFloat(10)^BigFloat(-20), -1) < 1e-16
+@test @inferred(lambertwbp(1e-20, -1)) - 1 - lambertw(-inv(big(MathConstants.e)) + BigFloat(10)^BigFloat(-20), -1) < 1e-16
 
-@test abs(lambertwbp(Complex(.01, .01), -1) - Complex(-0.2755038208041206, -0.1277888928494641)) < 1e-14
+@test abs(@inferred(lambertwbp(Complex(.01, .01), -1)) - Complex(-0.2755038208041206, -0.1277888928494641)) < 1e-14
 
 end  # if Int != Int32

--- a/test/lambertw.jl
+++ b/test/lambertw.jl
@@ -1,94 +1,90 @@
-using Compat
-
-import Compat.MathConstants
-
 ### domain errors
 
-@test_throws DomainError lambertw(-2.0,0)
-@test_throws DomainError lambertw(-2.0,-1)
-@test_throws DomainError lambertw(-2.0,1)
+@test_throws DomainError lambertw(-2.0, 0)
+@test_throws DomainError lambertw(-2.0, -1)
+@test_throws DomainError lambertw(-2.0, 1)
 @test isnan(lambertw(NaN))
 
 ## math constant e
-@test_throws DomainError lambertw(MathConstants.e,1)
-@test_throws DomainError lambertw(MathConstants.e,-1)
+@test_throws DomainError lambertw(MathConstants.e, 1)
+@test_throws DomainError lambertw(MathConstants.e, -1)
 
 ## integer arguments return floating point types
-@test typeof(lambertw(0)) <: AbstractFloat
+@test lambertw(0) isa AbstractFloat
 @test lambertw(0) == 0
 
 ### math constant, MathConstants.e e
 
 # could return math const e, but this would break type stability
-@test typeof(lambertw(1)) <: AbstractFloat
-@test lambertw(MathConstants.e,0) == 1
+@test lambertw(1) isa AbstractFloat
+@test lambertw(MathConstants.e, 0) == 1
 
 ## value at branch point where real branches meet
-@test lambertw(-1/MathConstants.e,0) == lambertw(-1/MathConstants.e,-1) == -1
-@test typeof(lambertw(-1/MathConstants.e,0)) == typeof(lambertw(-1/MathConstants.e,-1)) <: AbstractFloat
+@test lambertw(-inv(MathConstants.e), 0) == lambertw(-inv(MathConstants.e), -1) == -1
+@test typeof(lambertw(-inv(MathConstants.e), 0)) == typeof(lambertw(-inv(MathConstants.e), -1)) <: AbstractFloat
 
 ## convert irrationals to float
 
 @test isapprox(lambertw(pi), 1.0736581947961492)
-@test isapprox(lambertw(pi,0), 1.0736581947961492)
+@test isapprox(lambertw(pi, 0), 1.0736581947961492)
 
 ### infinite args or return values
 
-@test lambertw(0,-1) == lambertw(0.0,-1) == -Inf
-@test lambertw(Inf,0) == Inf
-@test lambertw(complex(Inf,1),0) == complex(Inf,1)
-@test lambertw(complex(Inf,0),1) == complex(Inf,2pi)
-@test lambertw(complex(-Inf,0),1) == complex(Inf,3pi)
-@test lambertw(complex(0.0,0.0),-1) == complex(-Inf,0.0)
+@test lambertw(0, -1) == lambertw(0.0, -1) == -Inf
+@test lambertw(Inf, 0) == Inf
+@test lambertw(complex(Inf, 1), 0) == complex(Inf, 1)
+@test lambertw(complex(Inf, 0), 1) == complex(Inf, 2pi)
+@test lambertw(complex(-Inf, 0), 1) == complex(Inf, 3pi)
+@test lambertw(complex(0.0, 0.0), -1) == complex(-Inf, 0.0)
 
 ## default branch is  k = 0
-@test lambertw(1.0) == lambertw(1.0,0)
+@test lambertw(1.0) == lambertw(1.0, 0)
 
 ## BigInt args return BigFloats
 @test typeof(lambertw(BigInt(0))) == BigFloat
 @test typeof(lambertw(BigInt(3))) == BigFloat
 
 ## Any Integer type allowed for second argument
-@test lambertw(-0.2,-1) == lambertw(-0.2,BigInt(-1))
+@test lambertw(-0.2, -1) == lambertw(-0.2, BigInt(-1))
 
 ## BigInt for second arg does not promote the type
-@test typeof(lambertw(-0.2,-1)) == typeof(lambertw(-0.2,BigInt(-1)))
+@test typeof(lambertw(-0.2, -1)) == typeof(lambertw(-0.2, BigInt(-1)))
 
-for (z,k,res) in [ (0,0 ,0), (complex(0,0),0 ,0),
-                   (complex(0.0,0),0 ,0), (complex(1.0,0),0, 0.567143290409783873) ]
+for (z, k, res) in [(0, 0 , 0), (complex(0, 0), 0 , 0),
+                    (complex(0.0, 0), 0 , 0), (complex(1.0, 0), 0, 0.567143290409783873)]
     if Int != Int32
-        @test isapprox(lambertw(z,k), res)
+        @test isapprox(lambertw(z, k), res)
         @test isapprox(lambertw(z), res)
     else
-        @test isapprox(lambertw(z,k), res; rtol = 1e-14)
+        @test isapprox(lambertw(z, k), res; rtol = 1e-14)
         @test isapprox(lambertw(z), res; rtol = 1e-14)
     end
 end
 
-for (z,k) in ((complex(1,1),2), (complex(1,1),0),(complex(.6,.6),0),
-              (complex(.6,-.6),0))
+for (z, k) in ((complex(1, 1), 2), (complex(1, 1), 0), (complex(.6, .6), 0),
+              (complex(.6, -.6), 0))
     let w
-        @test (w = lambertw(z,k) ; true)
+        @test (w = lambertw(z, k) ; true)
         @test abs(w*exp(w) - z) < 1e-15
     end
 end
 
-@test abs(lambertw(complex(-3.0,-4.0),0) - Complex(1.075073066569255, -1.3251023817343588)) < 1e-14
-@test abs(lambertw(complex(-3.0,-4.0),1) - Complex(0.5887666813694675, 2.7118802109452247)) < 1e-14
-@test (lambertw(complex(.3,.3),0); true)
+@test abs(lambertw(complex(-3.0, -4.0), 0) - Complex(1.075073066569255, -1.3251023817343588)) < 1e-14
+@test abs(lambertw(complex(-3.0, -4.0), 1) - Complex(0.5887666813694675, 2.7118802109452247)) < 1e-14
+@test (lambertw(complex(.3, .3), 0); true)
 
 # bug fix
 # The routine will start at -1/e + eps * im, rather than -1/e + 0im,
 # otherwise root finding will fail
 if Int != Int32
-    @test abs(lambertw(-1.0/MathConstants.e  + 0im,-1)) == 1
+    @test abs(lambertw(-inv(MathConstants.e) + 0im, -1)) == 1
 else
-    @test abs(lambertw(-1.0/MathConstants.e  + 0im,-1) + 1) < 1e-7
+    @test abs(lambertw(-inv(MathConstants.e) + 0im, -1) + 1) < 1e-7
 end
 # lambertw for BigFloat is more precise than Float64. Note
 # that 70 digits in test is about 35 digits in W
 let W
-    for z in [ BigFloat(1),  BigFloat(2), complex(BigFloat(1), BigFloat(1))]
+    for z in [BigFloat(1), BigFloat(2), complex(BigFloat(1), BigFloat(1))]
         @test (W = lambertw(z); true)
         @test abs(z - W * exp(W)) < BigFloat(1)^(-70)
     end
@@ -104,16 +100,16 @@ let sp = precision(BigFloat)
 end
 
 @test lambertw(1) == float(SpecialFunctions.omega)
-@test convert(Float16,SpecialFunctions.omega) == convert(Float16,0.5674)
-@test convert(Float32,SpecialFunctions.omega) == 0.56714326f0
+@test convert(Float16, SpecialFunctions.omega) == convert(Float16, 0.5674)
+@test convert(Float32, SpecialFunctions.omega) == 0.56714326f0
 @test lambertw(BigInt(1)) == big(SpecialFunctions.omega)
 
 ###  expansion about branch point
 
 # not a domain error, but not implemented
-@test_throws ArgumentError lambertwbp(1,1)
+@test_throws ArgumentError lambertwbp(1, 1)
 
-@test_throws DomainError lambertw(.3,2)
+@test_throws DomainError lambertw(.3, 2)
 
 # Expansions about branch point converges almost to machine precision
 # except near the radius of convergence.
@@ -125,7 +121,7 @@ if Int != Int32
 let sp = precision(BigFloat), z = BigFloat(1)/10^12, wo, xdiff
     setprecision(2048)
     for i in 1:300
-        innerarg = z-1/big(MathConstants.e)
+        innerarg = z - inv(big(MathConstants.e))
 
         # branch k = 0
         @test (wo = lambertwbp(Float64(z)); xdiff = abs(-1 + wo - lambertw(innerarg)); true)
@@ -135,7 +131,7 @@ let sp = precision(BigFloat), z = BigFloat(1)/10^12, wo, xdiff
         @test xdiff < 5e-16
 
         #  branch k = -1
-        @test (wo = lambertwbp(Float64(z),-1); xdiff = abs(-1 + wo - lambertw(innerarg,-1)); true)
+        @test (wo = lambertwbp(Float64(z), -1); xdiff = abs(-1 + wo - lambertw(innerarg, -1)); true)
         if xdiff > 5e-16
             println(Float64(z), " ", Float64(xdiff))
         end
@@ -149,8 +145,8 @@ end
 
 # test the expansion about branch point for k=-1,
 # by comparing to exact BigFloat calculation.
-@test lambertwbp(1e-20,-1) - 1 - lambertw(-BigFloat(1)/big(MathConstants.e)+ BigFloat(1)/BigFloat(10)^BigFloat(20),-1) < 1e-16
+@test lambertwbp(1e-20, -1) - 1 - lambertw(-inv(big(MathConstants.e)) + BigFloat(10)^BigFloat(-20), -1) < 1e-16
 
-@test abs(lambertwbp(Complex(.01,.01),-1) - Complex(-0.2755038208041206, -0.1277888928494641)) < 1e-14
+@test abs(lambertwbp(Complex(.01, .01), -1) - Complex(-0.2755038208041206, -0.1277888928494641)) < 1e-14
 
 end  # if Int != Int32

--- a/test/lambertw.jl
+++ b/test/lambertw.jl
@@ -1,5 +1,6 @@
 ### domain errors
-using IrrationalConstants
+using SpecialFunctions: inve # FIXME temporary until the fate of inve is decided
+#using IrrationalConstants
 
 @test_throws DomainError lambertw(-2.0, 0)
 @test_throws DomainError lambertw(-2.0, -1)

--- a/test/lambertw.jl
+++ b/test/lambertw.jl
@@ -1,4 +1,5 @@
 ### domain errors
+using IrrationalConstants
 
 @test_throws DomainError lambertw(-2.0, 0)
 @test_throws DomainError lambertw(-2.0, -1)
@@ -21,8 +22,8 @@
 @test @inferred(lambertw(MathConstants.e, 0)) == 1
 
 ## value at branch point where real branches meet
-@test lambertw(-inv(MathConstants.e), 0) == lambertw(-inv(MathConstants.e), -1) == -1
-@test typeof(lambertw(-inv(MathConstants.e), 0)) == typeof(lambertw(-inv(MathConstants.e), -1)) <: AbstractFloat
+@test lambertw(-inve, 0) == lambertw(-inve, -1) == -1
+@test typeof(lambertw(-inve, 0)) == typeof(lambertw(-inve, -1)) <: AbstractFloat
 
 ## convert irrationals to float
 
@@ -76,7 +77,7 @@ end
 # bug fix
 # The routine will start at -1/e + eps * im, rather than -1/e + 0im,
 # otherwise root finding will fail
-@test lambertw(-inv(MathConstants.e) + 0im, -1) ≈ -1 atol=1e-7
+@test lambertw(-inve + 0im, -1) ≈ -1 atol=1e-7
 
 # lambertw for BigFloat is more precise than Float64. Note
 # that 70 digits in test is about 35 digits in W
@@ -104,9 +105,9 @@ end
 @testset "lambertwbp()" begin
     # not a domain error, but not implemented
     @test_throws ArgumentError lambertwbp(1, 1)
-    @test_throws ArgumentError lambertwbp(inv(MathConstants.e) + 1e-5, 2)
-    @test_throws DomainError lambertwbp(inv(MathConstants.e) + 1e-5, 0)
-    @test_throws DomainError lambertwbp(inv(MathConstants.e) + 1e-5, -1)
+    @test_throws ArgumentError lambertwbp(inve + 1e-5, 2)
+    @test_throws DomainError lambertwbp(inve + 1e-5, 0)
+    @test_throws DomainError lambertwbp(inve + 1e-5, -1)
 
     # Expansions about branch point converges almost to machine precision
     # except near the radius of convergence.
@@ -116,8 +117,8 @@ end
         setprecision(2048) do
             z = BigFloat(10)^(-12)
             for _ in 1:300
-                @test lambertwbp(Float64(z)) ≈ 1 + lambertw(z - inv(big(MathConstants.e))) atol=5e-16
-                @test lambertwbp(Float64(z), -1) ≈ 1 + lambertw(z - inv(big(MathConstants.e)), -1) atol=5e-16
+                @test lambertwbp(Float64(z)) ≈ 1 + lambertw(z - big(inve)) atol=5e-16
+                @test lambertwbp(Float64(z), -1) ≈ 1 + lambertw(z - big(inve), -1) atol=5e-15
 
                 z *= 1.1
                 if z > 0.23 break end
@@ -127,6 +128,6 @@ end
 
     # test the expansion about branch point for k=-1,
     # by comparing to exact BigFloat calculation.
-    @test @inferred(lambertwbp(1e-20, -1)) ≈ 1 + lambertw(-inv(big(MathConstants.e)) + BigFloat(10)^(-20), -1) atol=1e-16
+    @test @inferred(lambertwbp(1e-20, -1)) ≈ 1 + lambertw(-big(inve) + BigFloat(10)^(-20), -1) atol=1e-16
     @test @inferred(lambertwbp(Complex(.01, .01), -1)) ≈ Complex(-0.2755038208041206, -0.1277888928494641) atol=1e-14
 end

--- a/test/lambertw.jl
+++ b/test/lambertw.jl
@@ -19,6 +19,8 @@ using IrrationalConstants
 
 # could return math const e, but this would break type stability
 @test @inferred(lambertw(1)) isa AbstractFloat
+@test @inferred(lambertw(1)) == float(LambertW.Omega)
+@test @inferred(lambertw(big(1))) == big(LambertW.Omega)
 @test @inferred(lambertw(MathConstants.e, 0)) == 1
 
 ## value at branch point where real branches meet
@@ -87,19 +89,30 @@ end
     @test z ≈ W*exp(W) atol=BigFloat(10)^(-70)
 end
 
-###  ω constant
+@testset "LambertW.Omega" begin
+    @test isapprox(LambertW.Ω * exp(LambertW.Ω), 1)
+    @test LambertW.Omega === LambertW.Ω
 
-## get ω from recursion and compare to value from lambertw
-let sp = precision(BigFloat)
-    setprecision(512)
-    @test lambertw(big(1)) == big(SpecialFunctions.omega)
-    setprecision(sp)
+    # lower than default precision
+    setprecision(BigFloat, 196) do
+        o = big(LambertW.Ω)
+        @test precision(o) == 196
+        @test isapprox(o * exp(o), 1, atol=eps(BigFloat))
+
+        oalias = big(LambertW.Omega)
+        @test o == oalias
+    end
+
+    # higher than default precision
+    setprecision(BigFloat, 2048) do
+        o = big(LambertW.Ω)
+        @test precision(o) == 2048
+        @test isapprox(o * exp(o), 1, atol=eps(BigFloat))
+
+        oalias = big(LambertW.Omega)
+        @test o == oalias
+    end
 end
-
-@test lambertw(1) == float(SpecialFunctions.omega)
-@test convert(Float16, SpecialFunctions.omega) == convert(Float16, 0.5674)
-@test convert(Float32, SpecialFunctions.omega) == 0.56714326f0
-@test lambertw(BigInt(1)) == big(SpecialFunctions.omega)
 
 ###  expansion about branch point
 @testset "lambertwbp()" begin

--- a/test/lambertw.jl
+++ b/test/lambertw.jl
@@ -1,0 +1,177 @@
+using Compat
+
+macro test_baddomain(expr)
+    if SpecialFunctions.LAMBERTW_USE_NAN
+        :(@test $(esc(expr)) === NaN)
+    else
+        :(@test_throws DomainError $(esc(expr)))
+    end
+end
+
+const euler =
+if isdefined(Base, :MathConstants)
+    Base.MathConstants.e
+else
+    e
+end
+
+### domain errors
+
+@test_baddomain lambertw(-2.0,0)
+@test_baddomain lambertw(-2.0,-1)
+@test_baddomain lambertw(-2.0,1)
+@test_baddomain lambertw(NaN)
+
+## math constant e
+@test_baddomain lambertw(euler,1)
+@test_baddomain lambertw(euler,-1)
+
+## integer arguments return floating point types
+@test typeof(lambertw(0)) <: AbstractFloat
+@test lambertw(0) == 0
+
+### math constant, euler e
+
+# could return math const e, but this would break type stability
+@test typeof(lambertw(1)) <: AbstractFloat
+@test lambertw(euler,0) == 1
+
+## value at branch point where real branches meet
+@test lambertw(-1/euler,0) == lambertw(-1/euler,-1) == -1
+@test typeof(lambertw(-1/euler,0)) == typeof(lambertw(-1/euler,-1)) <: AbstractFloat
+
+## convert irrationals to float
+
+@test isapprox(lambertw(pi), 1.0736581947961492)
+@test isapprox(lambertw(pi,0), 1.0736581947961492)
+
+### infinite args or return values
+
+@test lambertw(0,-1) == lambertw(0.0,-1) == -Inf
+@test lambertw(Inf,0) == Inf
+@test lambertw(complex(Inf,1),0) == complex(Inf,1)
+@test lambertw(complex(Inf,0),1) == complex(Inf,2pi)
+@test lambertw(complex(-Inf,0),1) == complex(Inf,3pi)
+@test lambertw(complex(0.0,0.0),-1) == complex(-Inf,0.0)
+
+## default branch is  k = 0
+@test lambertw(1.0) == lambertw(1.0,0)
+
+## BigInt args return BigFloats
+@test typeof(lambertw(BigInt(0))) == BigFloat
+@test typeof(lambertw(BigInt(3))) == BigFloat
+
+## Any Integer type allowed for second argument
+@test lambertw(-0.2,-1) == lambertw(-0.2,BigInt(-1))
+
+## BigInt for second arg does not promote the type
+@test typeof(lambertw(-0.2,-1)) == typeof(lambertw(-0.2,BigInt(-1)))
+
+for (z,k,res) in [ (0,0 ,0), (complex(0,0),0 ,0),
+                   (complex(0.0,0),0 ,0), (complex(1.0,0),0, 0.567143290409783873) ]
+    if Int != Int32
+        @test isapprox(lambertw(z,k), res)
+        @test isapprox(lambertw(z), res)
+    else
+        @test isapprox(lambertw(z,k), res; rtol = 1e-14)
+        @test isapprox(lambertw(z), res; rtol = 1e-14)
+    end
+end
+
+for (z,k) in ((complex(1,1),2), (complex(1,1),0),(complex(.6,.6),0),
+              (complex(.6,-.6),0))
+    let w
+        @test (w = lambertw(z,k) ; true)
+        @test abs(w*exp(w) - z) < 1e-15
+    end
+end
+
+@test abs(lambertw(complex(-3.0,-4.0),0) - Complex(1.075073066569255, -1.3251023817343588)) < 1e-14
+@test abs(lambertw(complex(-3.0,-4.0),1) - Complex(0.5887666813694675, 2.7118802109452247)) < 1e-14
+@test (lambertw(complex(.3,.3),0); true)
+
+# bug fix
+# The routine will start at -1/e + eps * im, rather than -1/e + 0im,
+# otherwise root finding will fail
+if Int != Int32
+    @test abs(lambertw(-1.0/euler  + 0im,-1)) == 1
+else
+    @test abs(lambertw(-1.0/euler  + 0im,-1) + 1) < 1e-7
+end
+# lambertw for BigFloat is more precise than Float64. Note
+# that 70 digits in test is about 35 digits in W
+let W
+    for z in [ BigFloat(1),  BigFloat(2), complex(BigFloat(1), BigFloat(1))]
+        @test (W = lambertw(z); true)
+        @test abs(z - W * exp(W)) < BigFloat(1)^(-70)
+    end
+end
+
+###  ω constant
+
+## get ω from recursion and compare to value from lambertw
+let sp = precision(BigFloat)
+  @compat  setprecision(512)
+    @test lambertw(big(1)) == big(SpecialFunctions.omega)
+  @compat  setprecision(sp)
+end
+
+@test lambertw(1) == float(SpecialFunctions.omega)
+@test convert(Float16,SpecialFunctions.omega) == convert(Float16,0.5674)
+@test convert(Float32,SpecialFunctions.omega) == 0.56714326f0
+@test lambertw(BigInt(1)) == big(SpecialFunctions.omega)
+
+###  expansion about branch point
+
+# not a domain error, but not implemented
+@test_throws ErrorException lambertwbp(1,1)
+
+@test_throws DomainError lambertw(.3,2)
+
+# Expansions about branch point converges almost to machine precision
+# except near the radius of convergence.
+# Complex args are not tested here.
+
+if Int != Int32
+
+let sp = precision(BigFloat), z = BigFloat(1)/10^12, wo, diff
+  @compat  setprecision(2048)
+    for i in 1:300
+        # k = 0
+        @test (wo = lambertwbp(Float64(z)); diff = abs(-1 + wo - lambertw(z-1/big(euler))); true)
+        if diff > 5e-16
+            println(Float64(z), " ", Float64(diff))
+        end
+        @test diff < 5e-16
+        #  k = -1
+        @test (wo = lambertwbp(Float64(z),-1); diff = abs(-1 + wo - lambertw(z-1/big(euler),-1)); true)
+        if diff > 5e-16
+            println(Float64(z), " ", Float64(diff))
+        end
+        @test diff < 5e-16
+        z  *= 1.1
+        if z > 0.23 break end
+    end
+ @compat  setprecision(sp)
+end
+
+# test the expansion about branch point for k=-1,
+# by comparing to exact BigFloat calculation.
+@test lambertwbp(1e-20,-1) - 1 - lambertw(-BigFloat(1)/big(euler)+ BigFloat(1)/BigFloat(10)^BigFloat(20),-1) < 1e-16
+
+@test abs(lambertwbp(Complex(.01,.01),-1) - Complex(-0.2755038208041206, -0.1277888928494641)) < 1e-14
+
+end
+
+## vectorization
+
+if VERSION >= v"0.5"
+    @test lambertw.([0.1,0.2]) == [lambertw(0.1),lambertw(0.2)]
+    @test lambertw.([0.1+im ,0.2-im]) == [lambertw(0.1+im),lambertw(0.2-im)]
+    @test lambertw.([0.1,-0.2],[0,-1]) == [lambertw(0.1,0),lambertw(-0.2,-1)]
+    @test lambertwbp.([.1,.2,.3],-1) == map(x -> lambertwbp(x,-1), [.1,.2,.3])
+else
+    @test lambertw([0.1,0.2]) == [lambertw(0.1),lambertw(0.2)]
+    @test lambertw([0.1+im ,0.2-im]) == [lambertw(0.1+im),lambertw(0.2-im)]
+    @test lambertw([0.1,-0.2],[0,-1]) == [lambertw(0.1,0),lambertw(-0.2,-1)]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,7 @@ tests = [
     "gamma",
     "logabsgamma",
     "sincosint",
+    "lambertw",
     "other_tests",
     "chainrules"
 ]


### PR DESCRIPTION
This is a fork of #84. I did:
  * rebased PR #84 against the current master
  * synced with the current master of [LambertW.jl](https://github.com/jlapeyre/LambertW.jl)
  * implemented suggestions from #84 
  * made some code simplifications that utilize compile-time dispatch
  * updated tests to check for compile-time type inference and improved approximation testing
  * ~~moved *Omega* and *1/e* constants to *IrrationalConstants.jl* (PR https://github.com/JuliaMath/IrrationalConstants.jl/issues/12), so this PR requires that *Omega* constant PR is merged~~uses *inve = 1/e* constant from https://github.com/JuliaMath/IrrationalConstants.jl/issues/13
  * [Omega constant](https://en.wikipedia.org/wiki/Omega_constant) is exported as `LambertW.Omega` or `LambertW.Ω`