### PR TITLE
Limit number of Newton iterations in beta_inc_inv

### DIFF
--- a/src/beta_inc.jl
+++ b/src/beta_inc.jl
@@ -919,6 +919,9 @@ function beta_inc_inv(a::Real, b::Real, p::Real, q::Real)
 end
 
 function _beta_inc_inv(a::Float64, b::Float64, p::Float64, q::Float64=1-p)
+
+    maxiter = 30
+
     #change tail if necessary
     if p > 0.5
         y, x = _beta_inc_inv(b, a, q, p)
@@ -968,8 +971,8 @@ function _beta_inc_inv(a::Float64, b::Float64, p::Float64, q::Float64=1-p)
     sq = 1.0
     prev = 1.0
 
-    if x < 0.0001
-        x = 0.0001
+    if x < 1e-200
+        x = 1e-200
     end
     if x > .9999
         x = .9999
@@ -1001,7 +1004,7 @@ function _beta_inc_inv(a::Float64, b::Float64, p::Float64, q::Float64=1-p)
     acu = exp10(iex)
 
     #iterate
-    while true
+    for i in 1:maxiter
         p_approx = beta_inc(a, b, x)[1]
         xin = x
         p_approx = (p_approx - p)*min(
@@ -1026,7 +1029,7 @@ function _beta_inc_inv(a::Float64, b::Float64, p::Float64, q::Float64=1-p)
         end
 
         #check if current estimate is acceptable
-
+        prev, acu, p_approx, x, tx
         if prev <= acu || p_approx^2 <= acu
             x = tx
             return (x, 1.0 - x)
@@ -1039,6 +1042,9 @@ function _beta_inc_inv(a::Float64, b::Float64, p::Float64, q::Float64=1-p)
         x = tx
         p_approx_prev = p_approx
     end
+
+    @debug "Newton iterations didn't converge in $maxiter iterations. The result might have reduced precision."
+    return (x, 1.0 - x)
 end
 
 function _beta_inc_inv(a::T, b::T, p::T) where {T<:Union{Float16, Float32}}

--- a/test/beta_inc.jl
+++ b/test/beta_inc.jl
@@ -299,4 +299,10 @@ end
         @test first(beta_inc_inv(1.0, 1.0, 1e-21)) ≈ 1e-21
         @test beta_inc_inv(1.0e30, 1.0, 0.49) == (1.0, 0.0)
     end
+
+    @testset "Avoid infinite loops" begin
+        # See https://github.com/JuliaStats/StatsFuns.jl/issues/133#issuecomment-1069602721
+        y = 2.0e-280
+        @test beta_inc(2.0, 1.0, beta_inc_inv(2.0, 1.0, y, 1.0)[1])[1] ≈ y
+    end
 end


### PR DESCRIPTION
and allow much smaller starting values.

I checked with the original Fortran version and it also hangs on the test problem. However, I think for different reasons since their tolerance is much higher than ours and the problem here is that we can't get below the `2.2250738585071875e-308` tolerance. I'm a little skeptical that such a small tolerance is generally workable but the Fortran source comments that

> Define accuracy and initialise.
> SAE below is the most negative decimal exponent which does not 
> cause an underflow; a value of -308 or thereabouts will often be 
> OK in double precision.

I put the limit at 30 which is completely arbitrary but with a good starting value, I believe it should be fine. I decided to raise a debug warning when the function hits the iteration max. The clamping away from zero and one in https://github.com/JuliaMath/SpecialFunctions.jl/blob/ce58a13925106d518daf644341ddb5e7c8d56bbb/src/beta_inc.jl#L971-L976 ruined small initial guesses, though, and it seems wrong to me to clamp away from zero with the same distance as the distance from one given the much higher density of numbers around zero. Without the change to the lower bound, the test case wouldn't reach a reasonable value within the 30 iterations limit.