### PR TITLE
Fix `beta_inc_inv` bug introduced in #399

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SpecialFunctions"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "2.1.5"
+version = "2.1.6"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/beta_inc.jl
+++ b/src/beta_inc.jl
@@ -967,7 +967,7 @@ function _beta_inc_inv(a::Float64, b::Float64, p::Float64, q::Float64=1-p)
     sq = 1.0
     prev = 1.0
 
-    x = clamp(x, fpu, prevfloat(1.0))
+    x = clamp(x, 0.0001, 0.9999)
 
     # This first argument was proposed in
     #

--- a/test/beta_inc.jl
+++ b/test/beta_inc.jl
@@ -305,4 +305,10 @@ end
         y = 2.0e-280
         @test beta_inc(2.0, 1.0, beta_inc_inv(2.0, 1.0, y, 1.0)[1])[1] ≈ y
     end
+
+    @testset "StatsFuns#145" begin
+        y = 0.92
+        @test beta_inc_inv(0.01, 0.1, y)[1] ≈ 0.7803014210919872
+        @test beta_inc(0.01, 0.1, beta_inc_inv(0.01, 0.1, y)[1])[1] ≈ y
+    end
 end


### PR DESCRIPTION
Apparently, #399 accidentally broke `beta_inc_inv` for some values, as reported in https://github.com/JuliaStats/StatsFuns.jl/issues/145.

The main issue seems to be that the initial `x` became much smaller in some cases (see https://github.com/JuliaMath/SpecialFunctions.jl/pull/399#discussion_r887253994). Increasing the lower bound significantly (the proposed `1e-200` in #396 is not sufficient), e.g., to `eps(Float64)`, fixes https://github.com/JuliaStats/StatsFuns.jl/issues/145.

However, for now I just reverted that change completely since it seems it is not needed for the bug fix in #399.