### PR TITLE
Fix `gamma_inc_inv` for some subnormal results

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SpecialFunctions"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "2.1.6"
+version = "2.1.7"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/test/gamma_inc.jl
+++ b/test/gamma_inc.jl
@@ -202,10 +202,22 @@ end
         end
     end
 
-    @testset "Issue 390 part 1" begin
+    @testset "Issue 390 + 403" begin
         a = 1.0309015068677239
         q = 0.020202020202020204
         @test last(gamma_inc(a, gamma_inc_inv(a, 1 - q, q))) ≈ q
+
+        a = 0.0016546512046778552
+        q = 0.7070707070707071
+        # Mathematica: InverseGammaRegularized[0.0016546512046778552, 0, 1-0.7070707070707071] = 3.04992226601142476643093`9.786272979013901*^-323
+        @test gamma_inc_inv(a, 1 - q, q) ≈ 3e-323
+    end
+
+    @testset "Distributions.jl: Issue 1567" begin
+        a = 0.0030345129757232197
+        p = 0.106
+        # Mathematica: InverseGammaRegularized[0.0030345129757232197, 0, 0.106] = 3.5283979699566549210055643`10.308610719322063*^-322
+        @test gamma_inc_inv(a, p, 1 - p) ≈ 3.5e-322
     end
 end
 


### PR DESCRIPTION
This PR fixes `gamma_inc_inv` for some subnormal results by fixing the branch in `gamma_inc` that @andreasnoack pointed out in https://github.com/JuliaMath/SpecialFunctions.jl/issues/390#issuecomment-1047244569. Additionally, the PR simplifies some calculations in `gamma_inc_inv`.

In the long term maybe https://github.com/JuliaMath/SpecialFunctions.jl/issues/390#issuecomment-1061600893 might be a better solution but this fixes some of the remaining issues for now it seems.

Fixes #390. Fixes #403 (duplicate of #390 it seems). Fixes https://github.com/JuliaStats/Distributions.jl/issues/1567.