### PR TITLE
Update gamma_inc documentation: Q(x,a) should be Q(a,x)

### DIFF
--- a/src/gamma_inc.jl
+++ b/src/gamma_inc.jl
@@ -843,7 +843,7 @@ P(a,x)=\\frac{1}{\\Gamma (a)} \\int_{0}^{x} e^{-t}t^{a-1} dt.
 ```
 and ``q=Q(a,x)`` is the Incomplete gamma function ratio given by:
 ```math
-Q(x,a)=\\frac{1}{\\Gamma (a)} \\int_{x}^{\\infty} e^{-t}t^{a-1} dt.
+Q(a,x)=\\frac{1}{\\Gamma (a)} \\int_{x}^{\\infty} e^{-t}t^{a-1} dt.
 ```
 In terms of these, the lower incomplete gamma function is
 ``\\gamma(a,x) = P(a,x) \\Gamma(a)`` and the upper incomplete


### PR DESCRIPTION
There is a minor inconsistency in the `gamma_inc` function documentation. Usually, the normalized upper incomplete gamma function is written as Q(a,x), but in the definition it was written as Q(x,a), and it can be confusing.