### PR TITLE
Implementation of inverse trigamma

### DIFF
--- a/src/SpecialFunctions.jl
+++ b/src/SpecialFunctions.jl
@@ -62,6 +62,7 @@ export
     invdigamma,
     polygamma,
     trigamma,
+    invtrigamma,
     gamma_inc,
     beta_inc,
     beta_inc_inv,
@@ -93,7 +94,8 @@ include("chainrules.jl")
 include("deprecated.jl")
 
 for f in (:digamma, :erf, :erfc, :erfcinv, :erfcx, :erfi, :erfinv, :logerfc, :logerfcx,
-          :eta, :gamma, :invdigamma, :logfactorial, :lgamma, :trigamma, :ellipk, :ellipe)
+          :eta, :gamma, :invdigamma, :invtrigamma, :logfactorial, :lgamma, :trigamma,
+          :ellipk, :ellipe)
     @eval $(f)(::Missing) = missing
 end
 for f in (:beta, :lbeta)

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -72,7 +72,10 @@ ChainRulesCore.@scalar_rule(
     inv(trigamma(invdigamma(x))),
 )
 ChainRulesCore.@scalar_rule(trigamma(x), polygamma(2, x))
-
+ChainRulesCore.@scalar_rule(
+    invtrigamma(x),
+    inv(polygamma(2, invtrigamma(x))),
+)
 # Bessel functions
 ChainRulesCore.@scalar_rule(
     besselj(ν, x),

--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -399,6 +399,49 @@ function _invdigamma(y::Float64)
 end
 
 """
+    invtrigamma(x)
+Compute the inverse [`trigamma`](@ref) function of `x`.
+"""
+invtrigamma(y::Number) = _invtrigamma(float(y))
+
+function _invtrigamma(y::Float64)
+    # Implementation of Newton algorithm described in
+    # "Linear Models and Empirical Bayes Methods for Assessing
+    #  Differential Expression in Microarray Experiments"
+    # (Appendix "Inversion of Trigamma Function")
+    #  by Gordon K. Smyth, 2004
+
+    if y <= 0
+        throw(DomainError(y, "Only positive `y` supported."))
+    end
+
+    if y > 1e7
+        return inv(sqrt(y))
+    elseif y < 1e-6
+        return inv(y)
+    end
+
+    x_old = inv(y) + 0.5
+    x_new = x_old
+
+    # Newton iteration
+    δ = Inf
+    iteration = 0
+    while δ > 1e-8 && iteration <= 25
+        iteration += 1
+        f_x_old = trigamma(x_old)
+        δx =  f_x_old*(1-f_x_old/y) / polygamma(2, x_old)
+        x_new = x_old + δx
+        δ = - δx / x_new
+        x_old = x_new
+    end
+
+    return x_new
+end
+
+
+
+"""
     zeta(s)
 
 Riemann zeta function

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -22,6 +22,10 @@
                 test_scalar(invdigamma, x)
             end
 
+            if x isa Real && x > 0
+                test_scalar(invtrigamma, x)
+            end
+
             if x isa Real && 0 < x < 1
                 test_scalar(erfinv, x)
                 test_scalar(erfcinv, x)

--- a/test/gamma.jl
+++ b/test/gamma.jl
@@ -47,6 +47,21 @@
         @test abs(invdigamma(2)) == abs(invdigamma(2.))
     end
 
+    @testset "invtrigamma" begin
+        for val in [0.001, 0.01, 0.1, 1.0, 10.0]
+            @test invtrigamma(trigamma(val)) ≈ val
+        end
+
+        for val in [1e-8, 0.001, 0.01, 0.1, 1.0, 10.0, 1e7, 1e9]
+                @test trigamma(invtrigamma(val)) ≈ val
+        end
+
+        @test_throws DomainError invtrigamma(-1.0)
+        @test invtrigamma(2) == invtrigamma(2.)
+    end
+
+    #@test "invtrigamma" begin
+
     @testset "polygamma" begin
         @test polygamma(20, 7.) ≈ -4.644616027240543262561198814998587152547
         @test polygamma(20, Float16(7.)) ≈ -4.644616027240543262561198814998587152547

--- a/test/gamma.jl
+++ b/test/gamma.jl
@@ -60,8 +60,6 @@
         @test invtrigamma(2) == invtrigamma(2.)
     end
 
-    #@test "invtrigamma" begin
-
     @testset "polygamma" begin
         @test polygamma(20, 7.) ≈ -4.644616027240543262561198814998587152547
         @test polygamma(20, Float16(7.)) ≈ -4.644616027240543262561198814998587152547

--- a/test/other_tests.jl
+++ b/test/other_tests.jl
@@ -76,7 +76,7 @@ end
 
 @testset "missing data" begin
     for f in (digamma, erf, erfc, erfcinv, erfcx, erfi, erfinv, eta, gamma,
-              invdigamma, logfactorial, trigamma)
+              invdigamma, invtrigamma, logfactorial, trigamma)
         @test f(missing) === missing
     end
     @test beta(1.0, missing) === missing
@@ -90,7 +90,7 @@ end
     for n in numbers
         @test abs(n) == SpecialFunctions.fastabs(n)
     end
-            
+
     numbers = [1im, 2 + 2im, 0 + 100im, 1e3 + 1e-10im]
     for n in numbers
         @test abs(real(n)) + abs(imag(n)) == SpecialFunctions.fastabs(n)


### PR DESCRIPTION
This PR implements the function `invtrigamma`, which is the inverse of `trigamma`.


The implementation follows the Appendix "Inversion of Trigamma Function"
in "Linear Models and Empirical Bayes Methods for Assessing Differential Expression in Microarray Experiments"
 by Gordon K. Smyth (2004). (The pdf is available, e.g., [here](http://www.people.vcu.edu/~mreimers/HTDA/Smythe%20-%20Empirical%20Bayes%20methods%20in%20microarrays.pdf).)
In implementing this I also tried to follow the `invdigamma` code.