### PR TITLE
Make inverse incomplete gamma and beta work with bignums

### DIFF
--- a/src/beta_inc.jl
+++ b/src/beta_inc.jl
@@ -1028,11 +1028,11 @@ function _beta_inc_inv(a::Float64, b::Float64, p::Float64, q::Float64=1-p)
     end
 end
 
-function _beta_inc_inv(a::T, b::T, p::T) where {T<:Union{Float16, Float32}}
+function _beta_inc_inv(a::T, b::T, p::T) where {T<:Real}
     x, y = _beta_inc_inv(Float64(a), Float64(b), Float64(p))
     T(x), T(y)
 end
-function _beta_inc_inv(a::T, b::T, p::T, q::T) where {T<:Union{Float16, Float32}}
+function _beta_inc_inv(a::T, b::T, p::T, q::T) where {T<:Real}
     x, y = _beta_inc_inv(Float64(a), Float64(b), Float64(p), Float64(q))
     T(x), T(y)
 end

--- a/src/gamma_inc.jl
+++ b/src/gamma_inc.jl
@@ -1086,7 +1086,7 @@ function __gamma_inc_inv(a::Float64, minpq::Float64, pcase::Bool)
     return x
 end
 
-function __gamma_inc_inv(a::T, minpq::T, pcase::Bool) where {T<:Union{Float16,Float32}}
+function __gamma_inc_inv(a::T, minpq::T, pcase::Bool) where {T<:Real}
     return T(__gamma_inc_inv(Float64(a), Float64(minpq), pcase))
 end
 

--- a/test/beta_inc.jl
+++ b/test/beta_inc.jl
@@ -311,4 +311,10 @@ end
         @test beta_inc_inv(0.01, 0.1, y)[1] ≈ 0.7803014210919872
         @test beta_inc(0.01, 0.1, beta_inc_inv(0.01, 0.1, y)[1])[1] ≈ y
     end
+
+    @testset "BigFloat" begin
+        @test beta_inc_inv(1, 2, big(1//2))[1] ≈ big(1//2) * (2 - sqrt(big(2))) atol=eps()
+        @test beta_inc_inv(1, 2, big(1//3))[1] ≈ big(1//3) * (3 - sqrt(big(6))) atol=eps()
+        @test beta_inc_inv(1, 2, big(1//4))[1] ≈ big(1//2) * (2 - sqrt(big(3))) atol=eps()
+    end
 end

--- a/test/gamma_inc.jl
+++ b/test/gamma_inc.jl
@@ -184,6 +184,7 @@ end
     @testset "Promotion of arguments" begin
         @test @inferred(gamma_inc_inv(1//2, 0.3f0, 0.7f0)) isa Float32
         @test @inferred(gamma_inc_inv(1, 0.2f0, 0.8f0)) isa Float32
+        @test @inferred(gamma_inc_inv(1, big(1//10), big(9//10))) isa BigFloat
     end
 
     @testset "Issue 385" begin


### PR DESCRIPTION
Currently both functions internally convert lower-precision values to `Float64` then convert the result back to the original type. The user-facing functions accept any `Real` but the internal functions they call accept only `Float16`, `Float32`, and `Float64`, seemingly under the assumption that those are the only possible results of `float`. However, `float` can also produce `BigFloat`s, which are accepted by the user-facing functions, but result in a `MethodError` from the internal functions. We can fix this by converting any `Real` to `Float64`, not just lower-precision, then converting back. This then permits passing `BigInt` and `BigFloat` values to `beta_inc_inv` and `gamma_inc_inv`.

This fixes an issue observed in LsqFit, which computes a quantile from a t-distribution using a `BigFloat`. Distributions passes that along to StatsFuns, which as of recently(ish) uses `beta_inc_inv`. This causes an error since `beta_inc_inv` could not handle `BigFloat`s. It didn't used to be a problem since previously the corresponding functions in StatsFuns called into libRmath and implicitly converted anything to `Float64`.