### PR TITLE
doc: add example and doctest for `gamma`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,7 @@
 using SpecialFunctions, Documenter
 
+# `using SpecialFunctions` for all doctests
+DocMeta.setdocmeta!(SpecialFunctions, :DocTestSetup, :(using SpecialFunctions); recursive=true)
 makedocs(modules=[SpecialFunctions],
          sitename="SpecialFunctions.jl",
          authors="Jeff Bezanson, Stefan Karpinski, Viral B. Shah, et al.",

--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -559,6 +559,40 @@ Compute the gamma function for complex ``z``, defined by
 ```
 and by analytic continuation in the whole complex plane.
 
+# Examples
+Special Values:
+```jldoctest
+julia> gamma(0)
+Inf
+
+julia> gamma(1)
+1.0
+
+julia> gamma(2)
+1.0
+```
+
+``\Gamma(0.5)^2 = \pi``
+```jldoctest
+julia> gamma(0.5)^2
+3.1415926535897936
+
+julia> gamma(0.5)^2 ≈ π
+true
+```
+
+For integer `n`: ``\Gamma(n+1) = prod(1:n) = factorial(n)``
+```jldoctest
+julia> gamma(4+1)
+24.0
+
+julia> prod(1:4)  # == 1*2*3*4
+24
+
+julia> gamma(4+1) == prod(1:4) == factorial(4)
+true
+```
+
 External links:
 [DLMF](https://dlmf.nist.gov/5.2.1),
 [Wikipedia](https://en.wikipedia.org/wiki/Gamma_function).


### PR DESCRIPTION
I'm not sure if those examples are too long, and if they are, I can break them up into the .md docs.

Compare to ...
- python - SciPy: https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.gamma.html
- Matlab: https://www.mathworks.com/help/matlab/ref/gamma.html

----
HTML output:

<img width="834" alt="image" src="https://github.com/JuliaMath/SpecialFunctions.jl/assets/5158738/c6a90bbe-3b36-4e27-b4f2-734793f0d9e2">
