### PR TITLE
Improve type stable in function `expint`

### DIFF
--- a/src/expint.jl
+++ b/src/expint.jl
@@ -131,7 +131,7 @@ end
 
 function _expint(z::Complex{Float64}, ::Val{expscaled}=Val{false}()) where {expscaled}
     if real(z) < 0
-        return _expint(1, z, 1000, Val{expscaled}())
+        return _expint(one(z), z, 1000, Val{expscaled}())
     else
         return expint_opt(z, Val{expscaled}())
     end
@@ -208,9 +208,10 @@ En_safe_gamma_term(ν::Integer, z::Real) = (z ≥ 0 || isodd(ν) ? 1 : -1) * exp
 # returns the two terms from the above equation separately
 function En_cf_gamma(ν::Number, z::Number, n::Int=1000)
     A = float(1 - ν)
-    B::typeof(A) = 1
-    Bprev::typeof(A) = 0
-    Aprev::typeof(A) = 1
+    A, _ = promote(A, z)
+    B = one(A)
+    Bprev = zero(B)
+    Aprev = one(A)
     ϵ = 10*eps(real(B))
     scale = sqrt(floatmax(real(A)))
 

--- a/src/expint.jl
+++ b/src/expint.jl
@@ -131,7 +131,7 @@ end
 
 function _expint(z::Complex{Float64}, ::Val{expscaled}=Val{false}()) where {expscaled}
     if real(z) < 0
-        return _expint(one(z), z, 1000, Val{expscaled}())
+        return _expint(1, z, 1000, Val{expscaled}())
     else
         return expint_opt(z, Val{expscaled}())
     end
@@ -207,11 +207,10 @@ En_safe_gamma_term(ν::Integer, z::Real) = (z ≥ 0 || isodd(ν) ? 1 : -1) * exp
 # https://functions.wolfram.com/GammaBetaErf/ExpIntegralE/10/0005/
 # returns the two terms from the above equation separately
 function En_cf_gamma(ν::Number, z::Number, n::Int=1000)
-    A = float(1 - ν)
-    A, _ = promote(A, z)
-    B = one(A)
+    A, z = map(float, promote(float(1 - ν), z))
+    B = oneunit(A)
     Bprev = zero(B)
-    Aprev = one(A)
+    Aprev = oneunit(A)
     ϵ = 10*eps(real(B))
     scale = sqrt(floatmax(real(A)))
 

--- a/src/expint.jl
+++ b/src/expint.jl
@@ -207,7 +207,7 @@ En_safe_gamma_term(ν::Integer, z::Real) = (z ≥ 0 || isodd(ν) ? 1 : -1) * exp
 # https://functions.wolfram.com/GammaBetaErf/ExpIntegralE/10/0005/
 # returns the two terms from the above equation separately
 function En_cf_gamma(ν::Number, z::Number, n::Int=1000)
-    A, z = map(float, promote(float(1 - ν), z))
+    A, z = map(float, promote(1 - ν, z))
     B = oneunit(A)
     Bprev = zero(B)
     Aprev = oneunit(A)

--- a/test/expint.jl
+++ b/test/expint.jl
@@ -158,6 +158,8 @@ using Base.MathConstants
                 Γ, cf, iter = SpecialFunctions.En_cf_gamma(1 / 2, x)
                 @test Γ + cf*exp(-x) ≈ y
             end
+            # type stability
+            @inferred SpecialFunctions.En_cf_gamma(1, 1.0 + 2.1im, 1000)
         end
         @testset "En_expand_origin" begin
             for (x, y) in zip(xs, ys)

--- a/test/expint.jl
+++ b/test/expint.jl
@@ -159,10 +159,8 @@ using Base.MathConstants
                 @test Γ + cf*exp(-x) ≈ y
             end
             # type stability
-            @inferred SpecialFunctions.En_cf_gamma(1, 1.0 + 2.1im, 1000)
-            @test SpecialFunctions.En_cf_gamma(1, 1.0 + 2.1im, 1000) isa Tuple{ComplexF64,ComplexF64,Int}
-            @inferred SpecialFunctions.En_cf_gamma(1, 1.0f0, 1000)
-            @test SpecialFunctions.En_cf_gamma(1, 1.0f0, 1000) isa Tuple{Float32,Float32,Int}
+            @test @inferred(SpecialFunctions.En_cf_gamma(1, 1.0 + 2.1im, 1000)) isa Tuple{ComplexF64,ComplexF64,Int}
+            @test @inferred(SpecialFunctions.En_cf_gamma(1, 1.0f0, 1000)) isa Tuple{Float32,Float32,Int}
         end
         @testset "En_expand_origin" begin
             for (x, y) in zip(xs, ys)

--- a/test/expint.jl
+++ b/test/expint.jl
@@ -160,6 +160,9 @@ using Base.MathConstants
             end
             # type stability
             @inferred SpecialFunctions.En_cf_gamma(1, 1.0 + 2.1im, 1000)
+            @test SpecialFunctions.En_cf_gamma(1, 1.0 + 2.1im, 1000) isa Tuple{ComplexF64,ComplexF64,Int}
+            @inferred SpecialFunctions.En_cf_gamma(1, 1.0f0, 1000)
+            @test SpecialFunctions.En_cf_gamma(1, 1.0f0, 1000) isa Tuple{Float32,Float32,Int}
         end
         @testset "En_expand_origin" begin
             for (x, y) in zip(xs, ys)


### PR DESCRIPTION
We found a type unstable code in `expint(z::ComplexF64)`

before this PR，the return type is unstable:

```julia
julia> @code_warntype SpecialFunctions.En_cf_gamma(1, rand(ComplexF64), 1000)
MethodInstance for SpecialFunctions.En_cf_gamma(::Int64, ::ComplexF64, ::Int64)
  from En_cf_gamma(ν::Number, z::Number, n::Int64) @ SpecialFunctions C:\Users\TR\github\SpecialFunctions.jl\src\expint.jl:209
Arguments
  #self#::Core.Const(SpecialFunctions.En_cf_gamma)
  ν::Int64
  z::ComplexF64
  n::Int64
Locals
...
Body::Tuple{ComplexF64, Union{Float64, ComplexF64}, Int64}
...
```

After this PR:

```julia
julia> @code_warntype SpecialFunctions.En_cf_gamma(1, rand(ComplexF64), 1000)
MethodInstance for SpecialFunctions.En_cf_gamma(::Int64, ::ComplexF64, ::Int64)
  from En_cf_gamma(ν::Number, z::Number, n::Int64) @ SpecialFunctions C:\Users\TR\github\SpecialFunctions.jl\src\expint.jl:209
Arguments
  #self#::Core.Const(SpecialFunctions.En_cf_gamma)
  ν::Int64
  z::ComplexF64
  n::Int64
Locals
...
Body::Tuple{ComplexF64, ComplexF64, Int64}
...
```







