### PR TITLE
doc: add missing doc for `beta_inc_inv`

### DIFF
--- a/docs/src/functions_overview.md
+++ b/docs/src/functions_overview.md
@@ -25,7 +25,7 @@ Here the *Special Functions* are listed according to the structure of [NIST Digi
 | [`logabsbeta(x,y)`](@ref SpecialFunctions.logabsbeta)                                          | accurate `log(abs(beta(x,y)))` for large `x` or `y`     |
 | [`logabsbinomial(x,y)`](@ref SpecialFunctions.logabsbinomial)                                          | accurate `log(abs(binomial(n,k)))` for large `n` and `k` near `n/2`     |
 | [`beta_inc(a,b,x,y)`](@ref SpecialFunctions.beta_inc)         | [incomplete beta function ratio Ix(a,b) and Iy(a,b)](https://en.wikipedia.org/wiki/Beta_function#Incomplete_beta_function) (i.e evaluates Ix(a,b) and Iy(a,b) and returns tuple (p,q)) |
-| [`beta_inc_inv(a,b,p,q)`](@ref SpecialFunctions.beta_inc_inv) | Inverse of the incomplete beta function |
+| [`beta_inc_inv(a,b,p,q)`](@ref SpecialFunctions.beta_inc_inv) | Inverse of the incomplete beta function (i.e evaluates x given ``I_{x}(a, b) = p``) |
 
 
 ## [Exponential and Trigonometric Integrals](https://dlmf.nist.gov/6)

--- a/docs/src/functions_overview.md
+++ b/docs/src/functions_overview.md
@@ -2,7 +2,10 @@
 Here the *Special Functions* are listed according to the structure of [NIST Digital Library of Mathematical Functions](https://dlmf.nist.gov/).
 
 
-## [Gamma Function](https://dlmf.nist.gov/5)
+## Gamma Function
+
+- [Gamma Function - DLMF](https://dlmf.nist.gov/5)
+
 | Function | Description |
 |:-------- |:----------- |
 | [`gamma(z)`](@ref SpecialFunctions.gamma(::Number)) | [gamma function](https://en.wikipedia.org/wiki/Gamma_function) ``\Gamma(z)`` |

--- a/docs/src/functions_overview.md
+++ b/docs/src/functions_overview.md
@@ -16,12 +16,13 @@ Here the *Special Functions* are listed according to the structure of [NIST Digi
 | [`gamma(a,z)`](@ref SpecialFunctions.gamma(::Number,::Number))  | [upper incomplete gamma function ``\Gamma(a,z)``](https://en.wikipedia.org/wiki/Incomplete_gamma_function) |
 | [`loggamma(a,z)`](@ref SpecialFunctions.loggamma(::Number,::Number))                                           | accurate `log(gamma(a,x))` for large arguments                 |
 | [`gamma_inc(a,x,IND)`](@ref SpecialFunctions.gamma_inc)  | [incomplete gamma function ratio P(a,x) and Q(a,x)](https://en.wikipedia.org/wiki/Incomplete_gamma_function) (i.e evaluates P(a,x) and Q(a,x)for accuracy specified by IND and returns tuple (p,q)) |
-| [`beta_inc(a,b,x,y)`](@ref SpecialFunctions.beta_inc)  | [incomplete beta function ratio Ix(a,b) and Iy(a,b)](https://en.wikipedia.org/wiki/Beta_function#Incomplete_beta_function) (i.e evaluates Ix(a,b) and Iy(a,b) and returns tuple (p,q)) |
 | [`gamma_inc_inv(a,p,q)`](@ref SpecialFunctions.gamma_inc_inv)  | [inverse of incomplete gamma function ratio P(a,x) and Q(a,x)](https://en.wikipedia.org/wiki/Incomplete_gamma_function) (i.e evaluates x given P(a,x)=p and Q(a,x)=q  |
 | [`beta(x,y)`](@ref SpecialFunctions.beta)                                           | [beta function](https://en.wikipedia.org/wiki/Beta_function) at `x,y`                                                                                           |
 | [`logbeta(x,y)`](@ref SpecialFunctions.logbeta)                                          | accurate `log(beta(x,y))` for large `x` or `y`      |
 | [`logabsbeta(x,y)`](@ref SpecialFunctions.logabsbeta)                                          | accurate `log(abs(beta(x,y)))` for large `x` or `y`     |
 | [`logabsbinomial(x,y)`](@ref SpecialFunctions.logabsbinomial)                                          | accurate `log(abs(binomial(n,k)))` for large `n` and `k` near `n/2`     |
+| [`beta_inc(a,b,x,y)`](@ref SpecialFunctions.beta_inc)         | [incomplete beta function ratio Ix(a,b) and Iy(a,b)](https://en.wikipedia.org/wiki/Beta_function#Incomplete_beta_function) (i.e evaluates Ix(a,b) and Iy(a,b) and returns tuple (p,q)) |
+| [`beta_inc_inv(a,b,p,q)`](@ref SpecialFunctions.beta_inc_inv) | Inverse of the incomplete beta function |
 
 
 ## [Exponential and Trigonometric Integrals](https://dlmf.nist.gov/6)

--- a/src/SpecialFunctions.jl
+++ b/src/SpecialFunctions.jl
@@ -58,14 +58,26 @@ export
     logerfcx,
     faddeeva,
     eta,
+
+    # Gamma functions
+    gamma,
+    loggamma,
+    logabsgamma,
+    logfactorial,
     digamma,
     invdigamma,
-    polygamma,
     trigamma,
+    polygamma,
     gamma_inc,
+    gamma_inc_inv,
+    # beta functions
+    beta,
+    logbeta,
+    logabsbeta,
+    logabsbinomial,
     beta_inc,
     beta_inc_inv,
-    gamma_inc_inv,
+
     ncbeta,
     ncF,
     hankelh1,

--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -2,8 +2,6 @@
 
 using Base.MPFR: MPFRRoundingMode, ROUNDING_MODE
 
-export gamma, loggamma, logabsgamma, beta, logbeta, logabsbeta, logfactorial, logabsbinomial
-
 const ComplexOrReal{T} = Union{T,Complex{T}}
 
 # Bernoulli numbers B_{2k}, using tabulated numerators and denominators from


### PR DESCRIPTION

- Export function only in SpecialFunctions.jl
- add missing doc for `beta_inc_inv`
