### PR TITLE
Test `min`, `lts` and `1` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,31 +14,27 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - 'min'
+          - 'lts'
           - '1'
         os:
           - ubuntu-latest
+          - macOS-latest
           - windows-latest
-        arch:
-          - x64
+        exclude:
+          - os: macOS-latest # Apple Silicon
+            version: 'min'
         include:
-          - os: macOS-13
-            arch: x64
-            version: 1
-          - os: macOS-latest
-            arch: aarch64
-            version: 1
-
+          - os: macOS-13 # Intel
+            version: 'min'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-        continue-on-error: ${{ matrix.version == 'nightly' }}
       - uses: julia-actions/julia-processcoverage@v1
         continue-on-error: true
       - uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
#477 changed the CI setup but IMO it's a bit dangerous to stop testing the oldest Julia version that is declared to be supported. It's just too easy to accidentally break compatibility by making use of newer Julia features.

I also increased the MacOS test coverage by testing 1.3 (`min`) on the Intel Macs but newer versions such as 1.10 (`lts`) and 1.11 (`1`) on the Apple Silicon runners (option 2 in https://discourse.julialang.org/t/how-to-fix-github-actions-ci-failures-with-julia-1-6-or-1-7-on-macos-latest-and-macos-14/117019).