### PR TITLE
Prepare a new release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SpecialFunctions"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "2.4.0"
+version = "2.5.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"


### PR DESCRIPTION
Bumps the package version such that #443 can be released. I updated to 2.5.0 to be able to potentially release fixes for older Julia versions as 2.4.x (a very unlikely situation but it felt safer to keep it as a possibility).