### PR TITLE
Fix premature truncation of the recurrence sum in zeta(s,z).

### DIFF
--- a/test/gamma.jl
+++ b/test/gamma.jl
@@ -277,6 +277,11 @@ end
     # issue #450
     @test SpecialFunctions.cotderiv(0, 2.0) == Inf
     @test_throws DomainError SpecialFunctions.cotderiv(-1, 2.0)
+
+    # issue #488
+    # TODO: Perhaps these bounds can be tightened in the future.
+    @test 3e-5 > relerr(zeta(-5.75, 0.5), 0.00140748175562420497363476203726333231826481355014969602507003223784179195)
+    @test 5e-5 > relerr(zeta(-8-1im, 0.5), -0.00345211118818533736386710113396098188185995501107179962865430034343404+0.0109171284162538012544319013865107198958348806377836496833453787991565im)
 end
 
 @testset "logabsbinomial" begin


### PR DESCRIPTION
As descriped in issue #488, skipping the recurrence sum or truncating early causes the function to break inside a region determined by shape of the cutoff. This rewrite also fixes another bug I encountered: sometimes the zero denominator term wasn't actually skipped, which caused sporadic failures.

This plot shows an example of how the error is improved relative to $(2^s-1)\zeta(s)$ in the affected area:
![relerr](https://github.com/user-attachments/assets/5168935a-4eac-48cb-add4-73ee637b8eab)

The accuracy still isn't perfect but the major breakage is fixed. Hopefully it can be improved in the future.
