### PR TITLE
Fix use of `floatmax`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SpecialFunctions"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "2.5.0"
+version = "2.5.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/expint.jl
+++ b/src/expint.jl
@@ -166,7 +166,7 @@ function En_cf_nogamma(ν::Number, z::Number, n::Int=1000)
     A::typeof(B) = 1
     Aprev::typeof(B) = 1
     ϵ = 10*eps(real(B))
-    scale = sqrt(floatmax(real(A)))
+    scale = sqrt(floatmax(typeof(real(A))))
 
     # two recurrence steps / loop
     iters = 1
@@ -212,7 +212,7 @@ function En_cf_gamma(ν::Number, z::Number, n::Int=1000)
     Bprev = zero(B)
     Aprev = oneunit(A)
     ϵ = 10*eps(real(B))
-    scale = sqrt(floatmax(real(A)))
+    scale = sqrt(floatmax(typeof(real(A))))
 
     iters = 0
     for i = 1:n


### PR DESCRIPTION
Fixes #475.

The docstring of `floatmax` only mentions and shows its application to types, not to values. Hence IMO as in other places in SpecialFunctions we should apply `floatmax` to types, not to values.

I didn't want to add a test with ForwardDiff since this would create a dependency cycle - ForwardDiff depends on SpecialFunctions, so e.g. breaking releases of SpecialFunctions could not be tested before a new version of ForwardDiff is released. Maybe a test should be added in ForwardDiff once the issue is fixed?