### PR TITLE
rft: make `gamma(a,x)` GPU compatible

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SpecialFunctions"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "2.7.1"
+version = "2.7.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/test/gamma_inc.jl
+++ b/test/gamma_inc.jl
@@ -281,11 +281,23 @@ end
 @testset "GPU compatibility ($FT)" for FT in (Float64, Float32, Float16)
     # Note: This test is a proxy for GPU compatibility by checking that the functions
     # are type stable and do not allocate memory. It does not launch any GPU kernels.
+    @testset "gamma type stability" begin
+        @test @inferred(gamma(FT(2), FT(0.5))) isa FT
+        @test @inferred(gamma(FT(2), FT(0.5) * im)) isa Complex{FT}
+        # Test with integer `a`
+        @test @inferred(gamma(2, FT(0.5))) isa FT
+        @test @inferred(gamma(2, FT(0.5) * im)) isa Complex{FT}
+    end
     @testset "gamma_inc type stability" begin
         @test @inferred(gamma_inc(FT(30.0), FT(29.99999), 0)) isa Tuple{FT,FT}
     end
     @testset "gamma_inc_inv type stability" begin
         @test @inferred(gamma_inc_inv(FT(1.0), FT(0.01), FT(0.99))) isa FT
+    end
+
+    @testset "gamma allocations" begin
+        @test iszero((FT -> @allocated(gamma(2, FT(0.5))))(FT))
+        @test iszero((FT -> @allocated(gamma(2, FT(0.5) * im)))(FT))
     end
 
     @testset "gamma_inc allocations" begin


### PR DESCRIPTION
# Purpose
This pull request refactors `src/expint.jl`, `src/gamma.jl` to make the upper incomplete gamma function `gamma(a, x)` GPU-compatible (verified on NVIDIA A100).

# Summary of changes
## `src/expint.jl`:
- Added targeted type constraints in `En_expand_origin_general`, `En_safe_expfact`, `En_expand_origin` to ensure their return types are consistent with the least precise floating point type of either `a` or `x`. These functions are conditionally used by `gamma(a,x)` through the call chain: `fn -> En_expand_origin -> _expint -> expint -> _gamma(a,x) -> gamma(a,x)`
    - Note: An alternative to this approach, would be to let these inner functions remain unstable, then do type conversion at the top-level.
    - Note 2: I don't personally use `gamma(a,x)` with complex arguments, so would appreciate an extra pair of eyes to verify that the way I get the floating point type `FT` from the arguments is reasonable.
- Added condition that guarantees termination of a while loop in `_expint`.
    - Note: This is an ad-hoc limit, which to my understanding, should never be reached mathematically.

## `src/gamma.jl`:
-  manually inlined single recursion in `_trigamma` and `_zeta` (similar to what I did in #514)
- updated `gamma(n::Union{Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64})` to call `gamma(Float64(n))` instead of `_gamma(Float64(n))` whenever `n > 20`. This subtle change allows the [CUDA.jl device override for `gamma`](https://github.com/JuliaGPU/CUDA.jl/blob/1810b7a8841dccd9fcc5f4f77a901707f18b872b/ext/SpecialFunctionsExt.jl#L34-L35) to work for this method.

## `test/gamma_inc.jl`:
- Added CI tests that verify that `gamma(a, x)` is type stable and allocation-free.
    - Note: Additional tests would be needed to verify that all runtime paths `gamma(a,x)` indeed do not allocate. I haven't done that in this PR