### PR TITLE
Fix allocation tests on Julia >= 1.13

### DIFF
--- a/test/gamma_inc.jl
+++ b/test/gamma_inc.jl
@@ -278,6 +278,14 @@ end
     @test_throws DomainError loggamma(6, -3.2)
 end
 
+# Run `f(args...)` twice and return only the result of the second call, so that
+# one-time costs of the first execution of a freshly compiled callsite are not
+# measured. On Julia >= 1.13 OpenLibm is a `Libdl.LazyLibrary`, so resolving the
+# target of a `ccall` into it allocates 16 bytes on that callsite's first
+# execution. Warming up with a separate call does not help, because the binding
+# is cached per callsite and not per callee.
+run_twice(f, args...) = (f(args...); f(args...))
+
 @testset "GPU compatibility ($FT)" for FT in (Float64, Float32, Float16)
     # Note: This test is a proxy for GPU compatibility by checking that the functions
     # are type stable and do not allocate memory. It does not launch any GPU kernels.
@@ -292,38 +300,38 @@ end
         # `@allocated` checks for allocations for specific code paths
         ## a >= 1
         ### gamma_inc_temme_1: simplified Temme expansion
-        @test iszero((FT -> @allocated(gamma_inc(FT(30.0), FT(29.99999), 0)))(FT))
+        @test iszero(run_twice(FT -> @allocated(gamma_inc(FT(30.0), FT(29.99999), 0)), FT))
         ### gamma_inc_minimax: minimax approximation
-        @test iszero((FT -> @allocated(gamma_inc(FT(100.0), FT(80.0), 0)))(FT))
+        @test iszero(run_twice(FT -> @allocated(gamma_inc(FT(100.0), FT(80.0), 0)), FT))
         ### gamma_inc_temme: Temme expansion
-        @test iszero((FT -> @allocated(gamma_inc(FT(100.0), FT(80.0), 1)))(FT))
+        @test iszero(run_twice(FT -> @allocated(gamma_inc(FT(100.0), FT(80.0), 1)), FT))
         ### gamma_inc_cf: Continued fraction
-        @test iszero((FT -> @allocated(gamma_inc(FT(1.7), FT(2.5))))(FT))
+        @test iszero(run_twice(FT -> @allocated(gamma_inc(FT(1.7), FT(2.5))), FT))
         ### gamma_inc_taylor: Taylor series
-        @test iszero((FT -> @allocated(gamma_inc(FT(11.1), FT(0.001))))(FT))
+        @test iszero(run_twice(FT -> @allocated(gamma_inc(FT(11.1), FT(0.001))), FT))
         ### gamma_inc_asym: Asymptotic expansion
-        @test iszero((FT -> @allocated(gamma_inc(FT(10.0), FT(35.0))))(FT))
+        @test iszero(run_twice(FT -> @allocated(gamma_inc(FT(10.0), FT(35.0))), FT))
         ### gamma_inc_fsum: Finite sums
-        @test iszero((FT -> @allocated(gamma_inc(FT(24.0), FT(25))))(FT))
+        @test iszero(run_twice(FT -> @allocated(gamma_inc(FT(24.0), FT(25))), FT))
         ## a==0.5
         ### erfc
-        @test iszero((FT -> @allocated(gamma_inc(FT(0.5), FT(0.5))))(FT))
+        @test iszero(run_twice(FT -> @allocated(gamma_inc(FT(0.5), FT(0.5))), FT))
         ## x < 1.1
         ### gamma_inc_taylor_x
-        @test iszero((FT -> @allocated(gamma_inc(FT(0.9), FT(0.8))))(FT))
+        @test iszero(run_twice(FT -> @allocated(gamma_inc(FT(0.9), FT(0.8))), FT))
         ## else
         ### gamma_inc_cf
-        @test iszero((FT -> @allocated(gamma_inc(FT(0.7), FT(2.5))))(FT))
+        @test iszero(run_twice(FT -> @allocated(gamma_inc(FT(0.7), FT(2.5))), FT))
     end
 
     @testset "gamma_inc_inv allocations" begin
         # `@allocated` checks for allocations for specific code paths
         ## x0 approximation paths
         ### gamma_inc_inv_psmall
-        @test iszero((FT -> @allocated(gamma_inc_inv(FT(1.0), FT(0.01), FT(0.99))))(FT))
+        @test iszero(run_twice(FT -> @allocated(gamma_inc_inv(FT(1.0), FT(0.01), FT(0.99))), FT))
         ### gamma_inc_inv_qsmall
-        @test iszero((FT -> @allocated(gamma_inc_inv(FT(5.0), FT(0.99), FT(0.01))))(FT))
+        @test iszero(run_twice(FT -> @allocated(gamma_inc_inv(FT(5.0), FT(0.99), FT(0.01))), FT))
         ### gamma_inc_inv_alarge
-        @test iszero((FT -> @allocated(gamma_inc_inv(FT(50.0), FT(0.3), FT(0.7))))(FT))
+        @test iszero(run_twice(FT -> @allocated(gamma_inc_inv(FT(50.0), FT(0.3), FT(0.7))), FT))
     end
 end


### PR DESCRIPTION
The `GPU compatibility` tests in `test/gamma_inc.jl` fail on Julia 1.13 (12 failures, 4 code paths x 3 float types), e.g.

```
gamma_inc allocations: Test Failed at test/gamma_inc.jl:301
  Expression: iszero(((FT->@allocated gamma_inc(FT(1.7), FT(2.5))))(FT))
   Evaluated: iszero(16)
```

OpenLibm is a `Libdl.LazyLibrary` on Julia >= 1.13, so a `ccall` into it can no longer be bound at compile time. Its target is resolved on first use and cached per callsite, and resolving one allocates 16 bytes.

Each test measured a single call of a newly created closure, and since the arguments are literals constant propagation inlines the `ccall` into that closure - `code_typed(FT -> gamma_inc(FT(1.7), FT(2.5)))` contains

```julia
Expr(:foreigncall, :((:tgamma, SpecialFunctions.libopenlibm)), ...)
```

So every measurement included the 16 bytes of resolving a fresh callsite. Only the paths that reach a `ccall` are affected: `gamma(a)` in `rgammax` for `1 <= a <= 20`, and `erfc` for `a == 0.5`. The other paths take the `stirling_error` (`a > 20`) or `rgamma1pm1` (`a < 1`) branches and are pure Julia, which is why they pass.

Warming up with a separate call does not help, because the lazy binding is cached per callsite and not per callee. So this now calls each closure twice and only asserts on the second measurement.

`test/gamma_inc.jl` passes on 1.10.11, 1.12.6 and 1.14.0-DEV (1.13.0-rc1 was unavailable locally, nightly reproduces the failure identically). A negative control `run_twice(FT -> @allocated(sum(zeros(FT, 100))), FT)` still reports 912/928, 480/512 and 256/272 bytes, so the tests still detect real allocations.

Note this is unrelated to #535 - the same failures are on the master push run [27935023667](https://github.com/JuliaMath/SpecialFunctions.jl/actions/runs/27935023667) and on #534.

🤖 Generated with [Claude Code](https://claude.com/claude-code)