### PR TITLE
Restrict * methods for SimplePoly to Number's

### DIFF
--- a/src/expint.jl
+++ b/src/expint.jl
@@ -5,8 +5,8 @@ struct SimplePoly{T}
     coeffs::Vector{T}
 end
 
-Base.:*(p::SimplePoly, c) = SimplePoly(p.coeffs * c)
-Base.:*(c, p::SimplePoly) = p * c
+Base.:*(p::SimplePoly, c::Number) = SimplePoly(p.coeffs * c)
+Base.:*(c::Number, p::SimplePoly) = p * c
 
 function Base.:+(p::SimplePoly{S}, q::SimplePoly{T}) where {S, T}
     n, m = length(p.coeffs), length(q.coeffs)


### PR DESCRIPTION
I think it should still be ok for differentiating through `expint()` with ForwardDiff, since `Dual <: Real`.

Fixes these invalidations seen when loading CurveFit.jl on 1.13:
```julia
 inserting *(p::SpecialFunctions.SimplePoly, c) @ SpecialFunctions ~/.julia/packages/SpecialFunctions/pIm7V/src/expint.jl:8 invalidated:                                                                                                       
   mt_backedges:  1: signature Tuple{typeof(*), Any, Nothing} triggered MethodInstance for Base.lerpi(::Integer, ::Integer, ::Nothing, ::Nothing) (0 children)                                                                                 
                  2: signature Tuple{typeof(*), Any, Compiler.ConstResult} triggered MethodInstance for Base.lerpi(::Integer, ::Integer, ::T, ::T) where T<:Compiler.ConstResult (0 children)                                                  
                  3: signature Tuple{typeof(*), Any, Compiler.CallMeta} triggered MethodInstance for Base.lerpi(::Integer, ::Integer, ::Compiler.CallMeta, ::Compiler.CallMeta) (0 children)                                                   
                  4: signature Tuple{typeof(*), Any, Compiler.MethodMatchInfo} triggered MethodInstance for Base.lerpi(::Integer, ::Integer, ::Compiler.MethodMatchInfo, ::Compiler.MethodMatchInfo) (0 children)                              
                  5: signature Tuple{typeof(*), Any, Compiler.AbstractIterationInfo} triggered MethodInstance for Base.lerpi(::Integer, ::Integer, ::Compiler.AbstractIterationInfo, ::Compiler.AbstractIterationInfo) (0 children)            
                  6: signature Tuple{typeof(*), Any, Compiler.ApplyCallInfo} triggered MethodInstance for Base.lerpi(::Integer, ::Integer, ::Compiler.ApplyCallInfo, ::Compiler.ApplyCallInfo) (0 children)                                    
                  7: signature Tuple{typeof(*), Any, Compiler.NewPhiCNode2} triggered MethodInstance for Base.lerpi(::Integer, ::Integer, ::Compiler.NewPhiCNode2, ::Compiler.NewPhiCNode2) (0 children)                                       
                  8: signature Tuple{typeof(*), Any, Compiler.ConstResult} triggered MethodInstance for Base.lerpi(::Integer, ::Integer, ::T, ::T) where T<:Compiler.ConstResult (1 children)                                                  
                  9: signature Tuple{typeof(*), Any, Compiler.AbstractIterationInfo} triggered MethodInstance for Base.lerpi(::Integer, ::Integer, ::Compiler.AbstractIterationInfo, ::Compiler.AbstractIterationInfo) (1 children)            
                 10: signature Tuple{typeof(*), Any, Module} triggered MethodInstance for Base.lerpi(::Integer, ::Integer, ::Module, ::Module) (4 children)                                                                                    
                 11: signature Tuple{typeof(*), Any, Compiler.CallMeta} triggered MethodInstance for Base.lerpi(::Integer, ::Integer, ::Compiler.CallMeta, ::Compiler.CallMeta) (10 children)                                                  
                 12: signature Tuple{typeof(*), Any, Compiler.MethodMatchInfo} triggered MethodInstance for Base.lerpi(::Integer, ::Integer, ::Compiler.MethodMatchInfo, ::Compiler.MethodMatchInfo) (10 children)                             
                 13: signature Tuple{typeof(*), Any, Compiler.ApplyCallInfo} triggered MethodInstance for Base.lerpi(::Integer, ::Integer, ::Compiler.ApplyCallInfo, ::Compiler.ApplyCallInfo) (10 children)                                   
                 14: signature Tuple{typeof(*), Any, Compiler.NewPhiCNode2} triggered MethodInstance for Base.lerpi(::Integer, ::Integer, ::Compiler.NewPhiCNode2, ::Compiler.NewPhiCNode2) (10 children)                                      
                 15: signature Tuple{typeof(*), Any, Tuple{LineNumberNode, Expr}} triggered MethodInstance for Base.lerpi(::Integer, ::Integer, ::Tuple{LineNumberNode, Expr}, ::Tuple{LineNumberNode, Expr}) (11 children)                    
                 16: signature Tuple{typeof(*), Any, Nothing} triggered MethodInstance for Base.lerpi(::Integer, ::Integer, ::Nothing, ::Nothing) (20 children)                                                                                
                 17: signature Tuple{typeof(*), Any, String} triggered MethodInstance for Base.lerpi(::Integer, ::Integer, ::String, ::String) (644 children)                                                                                  
```