### PR TITLE
Restore integer truncation semantics from BPSER and BUP in the beta_inc translation

### DIFF
--- a/src/beta_inc.jl
+++ b/src/beta_inc.jl
@@ -557,8 +557,9 @@ function beta_inc_power_series(a::Float64, b::Float64, x::Float64, epps::Float64
             end
         elseif b0 > 1.0
             u = loggamma1p(a0)
-            m = b0 - 1.0
-            if m >= 1.0
+            # In BPSER, M is implicitly declared INTEGER, so the assignment truncates
+            m = trunc(Int, b0 - 1.0)
+            if m >= 1
                 c = 1.0
                 for i = 1:m
                     b0 -= 1.0
@@ -640,8 +641,9 @@ function beta_inc_diff(a::Float64, b::Float64, x::Float64, y::Float64, n::Intege
     mu = 0.0
     d = 1.0
     if n != 1 && a >= 1.0 && apb >= 1.1*ap1
-        mu = abs(exparg_n)
-        k = exparg_p
+        # In BUP, MU and K are implicitly declared INTEGER, so the assignments truncate
+        mu = trunc(abs(exparg_n))
+        k = trunc(exparg_p)
         if k < mu
             mu = k
         end


### PR DESCRIPTION
While looking into JuliaStats/StatsFuns.jl#228 (Student-t CDF/quantile performance), I audited the `beta_inc` translation against the original NSWC Fortran source (https://github.com/jacobwilliams/nswc, `BRATIO` and its subroutines). The Fortran routines rely on implicit typing — variables starting with `I`–`N` are `INTEGER` unless declared `REAL`, and assigning a real expression to them truncates. The translation handles this correctly in several places (`BRATIO`'s `N = B0`, `BRCOMP`'s `N = B0 - 1.0`, `BUP`'s `K = R`), but two spots were missed:

1. **`BPSER` (`beta_inc_power_series`)**: `M = B0 - 1.0` truncates (`BPSER` declares only `N` as `REAL`), and `DO 41 I = 1,M` is an integer loop. The translation kept `m` as a `Float64` and iterated `for i = 1:m` over a `Float64` range, which constructs a `TwicePrecision`-backed `StepRangeLen` on every call — for a loop that typically runs a handful of times. The iteration count happens to coincide with the truncated Fortran semantics, so this is a pure performance fix: ~40 ns flat per call on the `min(a,b) < 1 < max(a,b) < 8` branch (the cost is the range construction, not the iterations).

2. **`BUP` (`beta_inc_diff`)**: `MU = ABS(EXPARG(1))` and `K = EXPARG(0)` truncate (`BUP` declares only `L` as `REAL`), so the scaling exponent is a whole number. This one has no measurable performance impact and produced bit-identical results in all tests; it is included for fidelity to the original.

Benchmarks (Apple Silicon, `@belapsed`, this branch vs current master; values bit-identical):

| case | master | this PR |
|---|---|---|
| `beta_inc(0.5, 2.5, 0.3103)` | 217 ns | 179 ns (−17%) |
| `StatsFuns.tdistcdf(5, 1.5)` | 223 ns | 182 ns (−19%) |
| `StatsFuns.tdistinvcdf(5, 0.95)` | 1004 ns | 849 ns (−15%) |
| `StatsFuns.tdistinvcdf(5, 1e-8)` | 1642 ns | 1354 ns (−18%) |

The quantile improves because `beta_inc_inv` evaluates `beta_inc` on every Newton iteration.

All `beta_inc`/`betanc` tests pass with results unchanged.

Disclosure: this PR was prepared by Claude Code at my direction; I have reviewed the changes and the benchmark methodology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
