### PR TITLE
Take same-precision arguments in expint's internal helpers, restrict the incomplete gamma

### DIFF
--- a/src/expint.jl
+++ b/src/expint.jl
@@ -165,8 +165,9 @@ function En_cf_nogamma(ν::Union{T,Complex{T}}, z::Union{T,Complex{T}}, n::Int=1
     Bprev::typeof(B) = z
     A::typeof(B) = 1
     Aprev::typeof(B) = 1
-    ϵ = 10*eps(real(B))
-    scale = sqrt(floatmax(typeof(real(A))))
+    ϵ = 10*eps(T)
+    # `A` and `B` are kept below this, which bounds the products in the test by `floatmax`/16
+    scale = sqrt(floatmax(T))/4
 
     # two recurrence steps / loop
     iters = 1
@@ -181,15 +182,16 @@ function En_cf_nogamma(ν::Union{T,Complex{T}}, z::Union{T,Complex{T}}, n::Int=1
         A, Aprev = A + (ν+i-1) * Aprev, A
         B, Bprev = B + (ν+i-1) * Bprev, B
 
-        i > 4 && abs(Aprev*B - A*Bprev) < ϵ*abs(B*Bprev) && break
-
         # rescale
-        if fastabs(A) > scale
+        if max(fastabs(A), fastabs(B)) > scale
             A     /= scale
             Aprev /= scale
             B     /= scale
             Bprev /= scale
         end
+
+        # relative test on the convergents Aprev/Bprev and A/B, cleared of their denominators
+        i > 4 && abs(Aprev*B - A*Bprev) < ϵ*abs(A*Bprev) && break
     end
 
     return A/B, iters

--- a/src/expint.jl
+++ b/src/expint.jl
@@ -131,7 +131,7 @@ end
 
 function _expint(z::Complex{Float64}, ::Val{expscaled}=Val{false}()) where {expscaled}
     if real(z) < 0
-        return _expint(1, z, 1000, Val{expscaled}())
+        return _expint(one(real(z)), z, 1000, Val{expscaled}())
     else
         return expint_opt(z, Val{expscaled}())
     end
@@ -160,8 +160,8 @@ end
 
 # Continued fraction for En(ν, z) that doesn't use a term with
 # the gamma function: https://functions.wolfram.com/GammaBetaErf/ExpIntegralE/10/0001/
-function En_cf_nogamma(ν::Number, z::Number, n::Int=1000)
-    B = float(z + ν)
+function En_cf_nogamma(ν::Union{T,Complex{T}}, z::Union{T,Complex{T}}, n::Int=1000) where {T<:Union{Float16,Float32,Float64}}
+    B = z + ν
     Bprev::typeof(B) = z
     A::typeof(B) = 1
     Aprev::typeof(B) = 1
@@ -196,18 +196,17 @@ function En_cf_nogamma(ν::Number, z::Number, n::Int=1000)
 end
 
 # Calculate Γ(1 - ν) * z^(ν-1) safely
-function En_safe_gamma_term(ν::Number, z::Number)
-    ν1 = 1 - oftype(z, ν)
+function En_safe_gamma_term(ν::Union{T,Complex{T}}, z::Union{T,Complex{T}}) where {T<:Union{Float16,Float32,Float64}}
+    ν1 = 1 - ν
     lgamma, lgammasign = ν1 isa Real ? logabsgamma(ν1) : (loggamma(ν1), 1)
     return lgammasign * exp((ν - 1)*log(z) + lgamma)
 end
-En_safe_gamma_term(ν::Integer, z::Real) = (z ≥ 0 || isodd(ν) ? 1 : -1) * exp((ν - 1)*log(abs(z)) + loggamma(1 - oftype(z, ν)))
 
 # continued fraction for En(ν, z) that uses the gamma function:
 # https://functions.wolfram.com/GammaBetaErf/ExpIntegralE/10/0005/
 # returns the two terms from the above equation separately
-function En_cf_gamma(ν::Number, z::Number, n::Int=1000)
-    A, z = map(float, promote(1 - ν, z))
+function En_cf_gamma(ν::Union{T,Complex{T}}, z::Union{T,Complex{T}}, n::Int=1000) where {T<:Union{Float16,Float32,Float64}}
+    A = 1 - ν + zero(z)
     B = oneunit(A)
     Bprev = zero(B)
     Aprev = oneunit(A)
@@ -243,7 +242,7 @@ end
 # picks between continued fraction representations in
 # En_cf_nogamma and En_cf_gamma
 # returns (evaluated result, # iterations used, whether En_cf_gamma was chosen)
-function En_cf(ν::Number, z::Number, niter::Int=1000)
+function En_cf(ν::Union{T,Complex{T}}, z::Union{T,Complex{T}}, niter::Int=1000) where {T<:Union{Float16,Float32,Float64}}
     if real(1-ν) > 0
         gammapart, cfpart, iters = En_cf_gamma(ν, z, niter)
         gammaabs, cfabs = abs(gammapart), abs(cfpart)
@@ -257,7 +256,8 @@ end
 
 # Compute expint(ν, z₀+Δ) given start = expint(ν, z₀), as described by [Amos 1980].
 # This is used to incrementally approach the negative real axis.
-function En_taylor(ν::Number, start::Number, z₀::Number, Δ::Number)
+function En_taylor(ν::Union{T,Complex{T}}, start::Union{T,Complex{T}}, z₀::Union{T,Complex{T}},
+                   Δ::Union{T,Complex{T}}) where {T<:Union{Float16,Float32,Float64}}
     a = exp(z₀) * start
     k, iters = 0, 0
     asum = a
@@ -283,7 +283,7 @@ end
 
 # series about origin, general ν
 # https://functions.wolfram.com/GammaBetaErf/ExpIntegralE/06/01/04/01/01/0003/
-function En_expand_origin_general(ν::Union{T,Complex{T}}, z::Union{T,Complex{T}}, niter::Int) where {T<:AbstractFloat}
+function En_expand_origin_general(ν::Union{T,Complex{T}}, z::Union{T,Complex{T}}, niter::Int) where {T<:Union{Float16,Float32,Float64}}
     # gammaterm = En_safe_gamma_term(ν, z)
     gammaterm = gamma(1-ν)*z^(ν-1)
     frac = one(z)
@@ -313,21 +313,9 @@ end
 # is O(δ^5) while the cancelling form loses accuracy like eps/δ; the two meet at
 # δ ~ eps(T)^(1/6), which is where the switch is made.
 #
-# There is no method for complex `BigFloat`, and none for any other `AbstractFloat`:
-# `polygamma` is not defined for them, and five terms could not serve that precision
-# in any case.
-#
-# Real `BigFloat` is delegated to MPFR instead, which computes
-# E_ν(z) = z^(ν-1) Γ(1-ν, z) without the cancellation. `mpfr_gamma_inc` needs z > 0
-# and its cost grows linearly in ν, so the series is kept where it is adequate anyway,
-# i.e. when no term fell into `blowup` and there was no cancellation to begin with.
-function En_origin_pole_series(ν::BigFloat, z::BigFloat, gammaterm, blowup, sumterm)
-    if !iszero(blowup) && z > 0 && ν < 1000
-        return z^(ν-1) * gamma(1-ν, z)
-    end
-    return gammaterm - (blowup + sumterm)
-end
-
+# There is no method for any other type: `polygamma` is not defined beyond these
+# precisions, and five terms could not serve a wider one in any case. `BigFloat` is
+# handled by `expint(::BigFloat, ::BigFloat)`, which delegates to MPFR.
 function En_origin_pole_series(ν::Union{T,Complex{T}}, z::Union{T,Complex{T}},
                                gammaterm, blowup, sumterm) where {T<:Union{Float16,Float32,Float64}}
     m = round(real(ν))
@@ -345,14 +333,12 @@ function En_origin_pole_series(ν::Union{T,Complex{T}}, z::Union{T,Complex{T}},
     # expressions for higher order terms found using:
     # https://gist.github.com/augustt198/348e8f9ba33c0248f1548309c47c6d0e
     ψ₀, ψ₁, ψ₂, ψ₃, ψ₄ = polygamma.((0,1,2,3,4), n+1)
-    series2 = ψ₀ + (3*ψ₀^2 + π^2 - 3*ψ₁)*δ/6 + (ψ₀^3 + (π^2 - 3ψ₁)*ψ₀ + ψ₂)δ^2/6
-    series2 += (7π^4 + 15*(ψ₀^4 + 2ψ₀^2 * (π^2 - 3ψ₁) + ψ₁*(-2π^2 + 3ψ₁) + 4ψ₀*ψ₂) - 15ψ₃)*δ^3/360
-    series2 += (3ψ₀^5 + ψ₀^3*(10π^2 - 30ψ₁) + 30ψ₀^2*ψ₂ + ψ₀*(45ψ₁^2 - 30π^2*ψ₁ - 15ψ₃ + 7π^4) - 30ψ₁*ψ₂ + 10π^2*ψ₂ + 3ψ₄)*δ^4/360
+    π², π⁴ = T(π)^2, T(π)^4
+    series2 = ψ₀ + (3*ψ₀^2 + π² - 3*ψ₁)*δ/6 + (ψ₀^3 + (π² - 3ψ₁)*ψ₀ + ψ₂)δ^2/6
+    series2 += (7π⁴ + 15*(ψ₀^4 + 2ψ₀^2 * (π² - 3ψ₁) + ψ₁*(-2π² + 3ψ₁) + 4ψ₀*ψ₂) - 15ψ₃)*δ^3/360
+    series2 += (3ψ₀^5 + ψ₀^3*(10π² - 30ψ₁) + 30ψ₀^2*ψ₂ + ψ₀*(45ψ₁^2 - 30π²*ψ₁ - 15ψ₃ + 7π⁴) - 30ψ₁*ψ₂ + 10π²*ψ₂ + 3ψ₄)*δ^4/360
 
-    # `π^2` and `π^4` above are `Float64`, so the series is evaluated in at least that
-    # precision and narrowed here
-    res = (series1 + series2) * En_safe_expfact(n, z) * z^(ν-n-1) - sumterm
-    return oftype(gammaterm, res)
+    return (series1 + series2) * En_safe_expfact(n, z) * z^(ν-n-1) - sumterm
 end
 
 # Compute (-z)^n / n!, avoiding overflow if possible.
@@ -367,13 +353,13 @@ end
 # takes over: the term is then negligible next to the sums the callers add it to, and
 # orders too large to loop over have to be handled as well (`expint(1e15, 2.5)` is
 # tested, and `Int` is 32 bits on some platforms).
-function En_safe_expfact(n::T, z::T) where {T<:AbstractFloat}
+function En_safe_expfact(n::T, z::T) where {T<:Union{Float16,Float32,Float64}}
     n < 12 && return _En_powerterm(n, z)
     sgn = z <= 0 ? one(T) : (isodd(n) ? -one(T) : one(T))
     return sgn * exp(n*log(abs(z)) - loggamma(n + one(T)))
 end
 
-function En_safe_expfact(n::T, z::Complex{T}) where {T<:AbstractFloat}
+function En_safe_expfact(n::T, z::Complex{T}) where {T<:Union{Float16,Float32,Float64}}
     n < 12 && return _En_powerterm(n, z)
     return exp(n*log(-z) - loggamma(n + one(T)))
 end
@@ -389,10 +375,10 @@ end
 
 # series about the origin, special case for integer n > 0
 # https://functions.wolfram.com/GammaBetaErf/ExpIntegralE/06/01/04/01/02/0005/
-function En_expand_origin_posint(n, z::Number, niter::Integer)
+function En_expand_origin_posint(n::T, z::Union{T,Complex{T}}, niter::Int) where {T<:Union{Float16,Float32,Float64}}
     frac = one(real(z))
-    gammaterm = En_safe_expfact(oftype(frac, n-1), z) # (-z)^(n-1) / (n-1)!
-    gammaterm *= digamma(oftype(frac,n)) - log(z)
+    gammaterm = En_safe_expfact(n-1, z) # (-z)^(n-1) / (n-1)!
+    gammaterm *= digamma(n) - log(z)
     sumterm = n == 1 ? zero(frac) : frac / (1 - n)
     k = 1
     ϵ = 10*eps(real(sumterm))
@@ -411,41 +397,45 @@ function En_expand_origin_posint(n, z::Number, niter::Integer)
     return gammaterm - sumterm
 end
 
-function En_expand_origin(ν::Number, z::Number, niter::Int)
+function En_expand_origin(ν::Union{T,Complex{T}}, z::Union{T,Complex{T}}, niter::Int) where {T<:Union{Float16,Float32,Float64}}
     if isinteger(ν) && real(ν) > 0
-        return real(ν) < (typemax(Int)>>2) ? En_expand_origin_posint(Int(real(ν)), z, niter) : En_expand_origin_posint(real(ν), z, niter)
+        return En_expand_origin_posint(real(ν), z, niter)
     else
-        # `En_expand_origin_general` takes both arguments at the same precision
-        T = typeof(one(real(z)))
-        return En_expand_origin_general(ν isa Real ? convert(T, ν) : convert(Complex{T}, ν), z, niter)
+        return En_expand_origin_general(ν, z, niter)
     end
 end
 
 # can find imaginary part of E_ν(x) for x on negative real axis analytically
 # https://functions.wolfram.com/GammaBetaErf/ExpIntegralE/04/05/01/0003/
-function En_imagbranchcut(ν::Union{T,Complex{T}}, z::Union{T,Complex{T}}) where {T<:AbstractFloat}
+function En_imagbranchcut(ν::T, z::Union{T,Complex{T}}) where {T<:Union{Float16,Float32,Float64}}
+    a = real(z)
+    s, c = sincospi(ν)
+    lgamma, lgammasign = logabsgamma(ν)
+    return -2 * lgammasign * Complex(c, -s) * π * exp((ν-1)*log(complex(a)) - lgamma) * im
+end
+function En_imagbranchcut(ν::Complex{T}, z::Union{T,Complex{T}}) where {T<:Union{Float16,Float32,Float64}}
     a = real(z)
     e1 = exp(π * imag(ν))
-    e2 = Complex(cospi(real(ν)), -sinpi(real(ν)))
-    lgamma, lgammasign = ν isa Real ? logabsgamma(ν) : (loggamma(ν), 1)
-    return -2 * lgammasign * e1 * π * e2 * exp((ν-1)*log(complex(a)) - lgamma) * im
+    s, c = sincospi(real(ν))
+    return -2 * e1 * Complex(c, -s) * π * exp((ν-1)*log(complex(a)) - loggamma(ν)) * im
 end
 
-function En_safeexpmult(z, a)
+# compute exp(z) * a, avoiding overflow of the exponential by shifting into the exponent
+function En_safeexpmult(z::Union{T,Complex{T}}, a::T) where {T<:Union{Float16,Float32,Float64}}
     zexp = exp(z)
-    if isinf(zexp) || iszero(zexp)
-        return a isa Real ? sign(a) * exp(z + log(abs(a))) : exp(z + log(a))
-    else
-        return zexp*a
-    end
+    return isinf(zexp) || iszero(zexp) ? sign(a) * exp(z + log(abs(a))) : zexp*a
+end
+function En_safeexpmult(z::Union{T,Complex{T}}, a::Complex{T}) where {T<:Union{Float16,Float32,Float64}}
+    zexp = exp(z)
+    return isinf(zexp) || iszero(zexp) ? exp(z + log(a)) : zexp*a
 end
 
-function _expint(ν::Number, z::Number, niter::Int=1000, ::Val{expscaled}=Val{false}()) where {expscaled}
+function _expint(ν::Union{T,Complex{T}}, z::Union{T,Complex{T}}, niter::Int=1000,
+                 ::Val{expscaled}=Val{false}()) where {T<:Union{Float16,Float32,Float64}, expscaled}
     if abs(ν) > 50 && !(isreal(ν) && real(ν) > 0)
         throw(ArgumentError("Unsupported order |ν| > 50 off the positive real axis"))
     end
 
-    z, = promote(float(z), ν)
     if isnan(ν) || isnan(z)
         return oftype(z, NaN) * z
     end
@@ -535,9 +525,7 @@ function _expint(ν::Number, z::Number, niter::Int=1000, ::Val{expscaled}=Val{fa
 
         # handle branch cut
         if imz == 0
-            # `En_imagbranchcut` takes both arguments at the same precision
-            νc = ν isa Real ? convert(real(typeof(z)), ν) : convert(complex(real(typeof(z))), ν)
-            bc = En_imagbranchcut(νc, z)
+            bc = En_imagbranchcut(ν, z)
             bit = !signbit(imag(z))
             sign = bit ? 1 : -1
             if isreal(ν)
@@ -565,7 +553,14 @@ External links:
 [DLMF 8.19](https://dlmf.nist.gov/8.19),
 [Wikipedia](https://en.wikipedia.org/wiki/Exponential_integral)
 """
-expint(ν::Number, z::Number, niter::Int=1000) = _expint(ν, z, niter, Val{false}())
+expint(ν::Number, z::Number, niter::Int=1000) =
+    _expint(promotereal(ν, float(z))..., niter, Val{false}())
+
+# For real `BigFloat` arguments MPFR's incomplete gamma gives E_ν(z) = z^(ν-1) Γ(1-ν, z)
+# directly, and unlike the series about the origin it does not cancel for `ν` near a
+# positive integer. It throws for z < 0, where Γ(1-ν, z) is generally complex. There is
+# no scaled counterpart in MPFR, so `expintx` has no `BigFloat` method.
+_expint(ν::BigFloat, z::BigFloat, niter::Int, ::Val{false}) = z^(ν-1) * gamma(1-ν, z)
 
 
 @doc raw"""
@@ -581,7 +576,8 @@ If ``\nu`` is not specified, ``\nu = 1`` is used. Arbitrary complex
 
 See also: [`expint(ν, z)`](@ref SpecialFunctions.expint)
 """
-expintx(ν::Number, z::Number, niter::Int=1000) = _expint(ν, z, niter, Val{true}())
+expintx(ν::Number, z::Number, niter::Int=1000) =
+    _expint(promotereal(ν, float(z))..., niter, Val{true}())
 
 ##############################################################################
 # expinti function Ei

--- a/src/expint.jl
+++ b/src/expint.jl
@@ -283,14 +283,14 @@ end
 
 # series about origin, general ν
 # https://functions.wolfram.com/GammaBetaErf/ExpIntegralE/06/01/04/01/01/0003/
-function En_expand_origin_general(ν::Number, z::Number, niter::Integer)
+function En_expand_origin_general(ν::Union{T,Complex{T}}, z::Union{T,Complex{T}}, niter::Int) where {T<:AbstractFloat}
     # gammaterm = En_safe_gamma_term(ν, z)
     gammaterm = gamma(1-ν)*z^(ν-1)
     frac = one(z)
     blowup  = abs(1 - ν) < 0.5 ? frac / (1 - ν) : zero(z)
     sumterm = abs(1 - ν) < 0.5 ? zero(z) : frac / (1 - ν)
     k = 1
-    ε = 10*eps(typeof(abs(frac)))
+    ε = 10*eps(T)
     while k < niter
         frac *= -z / k
         prev = sumterm
@@ -305,50 +305,93 @@ function En_expand_origin_general(ν::Number, z::Number, niter::Integer)
         k += 1
     end
 
-    if real(ν+z) isa Union{Float64, Float32} && abs(gammaterm - blowup) < 1e-3 * abs(blowup)
-        δ = round(ν) - ν
-        n = real(round(ν)) - 1
+    return En_origin_pole_series(ν, z, gammaterm, blowup, sumterm)
+end
 
-        # (1 - z^δ)/δ series
-        logz = log(z)
-        series1 = -logz - logz^2*δ/2 - logz^3*δ^2/6 - logz^4*δ^3/24 - logz^5*δ^4/120
-
-        # due to https://functions.wolfram.com/GammaBetaErf/Gamma/06/01/05/01/0004/
-        # expressions for higher order terms found using:
-        # https://gist.github.com/augustt198/348e8f9ba33c0248f1548309c47c6d0e
-        ψ₀, ψ₁, ψ₂, ψ₃, ψ₄ = polygamma.((0,1,2,3,4), n+1)
-        series2 = ψ₀ + (3*ψ₀^2 + π^2 - 3*ψ₁)*δ/6 + (ψ₀^3 + (π^2 - 3ψ₁)*ψ₀ + ψ₂)δ^2/6
-        series2 += (7π^4 + 15*(ψ₀^4 + 2ψ₀^2 * (π^2 - 3ψ₁) + ψ₁*(-2π^2 + 3ψ₁) + 4ψ₀*ψ₂) - 15ψ₃)*δ^3/360
-        series2 += (3ψ₀^5 + ψ₀^3*(10π^2 - 30ψ₁) + 30ψ₀^2*ψ₂ + ψ₀*(45ψ₁^2 - 30π^2*ψ₁ - 15ψ₃ + 7π^4) - 30ψ₁*ψ₂ + 10π^2*ψ₂ + 3ψ₄)*δ^4/360
-
-        return (series1 + series2) * En_safe_expfact(n, z) * z^(ν-n-1) - sumterm
+# Near a positive integer order the two leading terms above cancel, and the expansion
+# in δ = round(real(ν)) - ν below is used instead. It is truncated after δ^4, so its error
+# is O(δ^5) while the cancelling form loses accuracy like eps/δ; the two meet at
+# δ ~ eps(T)^(1/6), which is where the switch is made.
+#
+# There is no method for complex `BigFloat`, and none for any other `AbstractFloat`:
+# `polygamma` is not defined for them, and five terms could not serve that precision
+# in any case.
+#
+# Real `BigFloat` is delegated to MPFR instead, which computes
+# E_ν(z) = z^(ν-1) Γ(1-ν, z) without the cancellation. `mpfr_gamma_inc` needs z > 0
+# and its cost grows linearly in ν, so the series is kept where it is adequate anyway,
+# i.e. when no term fell into `blowup` and there was no cancellation to begin with.
+function En_origin_pole_series(ν::BigFloat, z::BigFloat, gammaterm, blowup, sumterm)
+    if !iszero(blowup) && z > 0 && ν < 1000
+        return z^(ν-1) * gamma(1-ν, z)
     end
     return gammaterm - (blowup + sumterm)
 end
 
-# compute (-z)^n / n!, avoiding overflow if possible, where n is an integer ≥ 0 (but not necessarily an Integer)
-function En_safe_expfact(n::Real, z::Number)
-    if n < 100
-        powerterm = one(z)
-        for i = 1:Int(n)
-            powerterm *= -z/i
-        end
-        return powerterm
-    else
-        if z isa Real
-            sgn = z ≤ 0 ? one(n) : (n <= typemax(Int) ? (isodd(Int(n)) ? -one(n) : one(n)) : (-1)^n)
-            return sgn * exp(n * log(abs(z)) - loggamma(n+1))
-        else
-            return exp(n * log(-z) - loggamma(n+1))
-        end
+function En_origin_pole_series(ν::Union{T,Complex{T}}, z::Union{T,Complex{T}},
+                               gammaterm, blowup, sumterm) where {T<:Union{Float16,Float32,Float64}}
+    m = round(real(ν))
+    δ = m - ν
+    if !(m >= 1 && abs(δ) < eps(T)^(1/6)/2)
+        return gammaterm - (blowup + sumterm)
     end
+    n = m - 1
+
+    # (1 - z^δ)/δ series
+    logz = log(z)
+    series1 = -logz - logz^2*δ/2 - logz^3*δ^2/6 - logz^4*δ^3/24 - logz^5*δ^4/120
+
+    # due to https://functions.wolfram.com/GammaBetaErf/Gamma/06/01/05/01/0004/
+    # expressions for higher order terms found using:
+    # https://gist.github.com/augustt198/348e8f9ba33c0248f1548309c47c6d0e
+    ψ₀, ψ₁, ψ₂, ψ₃, ψ₄ = polygamma.((0,1,2,3,4), n+1)
+    series2 = ψ₀ + (3*ψ₀^2 + π^2 - 3*ψ₁)*δ/6 + (ψ₀^3 + (π^2 - 3ψ₁)*ψ₀ + ψ₂)δ^2/6
+    series2 += (7π^4 + 15*(ψ₀^4 + 2ψ₀^2 * (π^2 - 3ψ₁) + ψ₁*(-2π^2 + 3ψ₁) + 4ψ₀*ψ₂) - 15ψ₃)*δ^3/360
+    series2 += (3ψ₀^5 + ψ₀^3*(10π^2 - 30ψ₁) + 30ψ₀^2*ψ₂ + ψ₀*(45ψ₁^2 - 30π^2*ψ₁ - 15ψ₃ + 7π^4) - 30ψ₁*ψ₂ + 10π^2*ψ₂ + 3ψ₄)*δ^4/360
+
+    # `π^2` and `π^4` above are `Float64`, so the series is evaluated in at least that
+    # precision and narrowed here
+    res = (series1 + series2) * En_safe_expfact(n, z) * z^(ν-n-1) - sumterm
+    return oftype(gammaterm, res)
+end
+
+# Compute (-z)^n / n!, avoiding overflow if possible.
+#
+# Internal helper. The callers guarantee that `n` is a whole number >= 0, that `z` is
+# non-zero, and that `n` and `z` have the same precision. There is deliberately no
+# promoting method, so a mismatch surfaces as a `MethodError` at the call site rather
+# than as a silent mixed precision computation.
+#
+# The product is used for small `n`, where the term is large enough to influence the
+# result and the loop is both cheap and more accurate. Above that the closed form
+# takes over: the term is then negligible next to the sums the callers add it to, and
+# orders too large to loop over have to be handled as well (`expint(1e15, 2.5)` is
+# tested, and `Int` is 32 bits on some platforms).
+function En_safe_expfact(n::T, z::T) where {T<:AbstractFloat}
+    n < 12 && return _En_powerterm(n, z)
+    sgn = z <= 0 ? one(T) : (isodd(n) ? -one(T) : one(T))
+    return sgn * exp(n*log(abs(z)) - loggamma(n + one(T)))
+end
+
+function En_safe_expfact(n::T, z::Complex{T}) where {T<:AbstractFloat}
+    n < 12 && return _En_powerterm(n, z)
+    return exp(n*log(-z) - loggamma(n + one(T)))
+end
+
+# (-z)^n / n! as a product, for whole n >= 0
+function _En_powerterm(n, z)
+    powerterm = one(z)
+    for i = 1:n
+        powerterm *= -z/i
+    end
+    return powerterm
 end
 
 # series about the origin, special case for integer n > 0
 # https://functions.wolfram.com/GammaBetaErf/ExpIntegralE/06/01/04/01/02/0005/
 function En_expand_origin_posint(n, z::Number, niter::Integer)
-    gammaterm = En_safe_expfact(n-1, z) # (-z)^(n-1) / (n-1)!
     frac = one(real(z))
+    gammaterm = En_safe_expfact(oftype(frac, n-1), z) # (-z)^(n-1) / (n-1)!
     gammaterm *= digamma(oftype(frac,n)) - log(z)
     sumterm = n == 1 ? zero(frac) : frac / (1 - n)
     k = 1
@@ -368,19 +411,21 @@ function En_expand_origin_posint(n, z::Number, niter::Integer)
     return gammaterm - sumterm
 end
 
-function En_expand_origin(ν::Number, z::Number, niter::Integer)
+function En_expand_origin(ν::Number, z::Number, niter::Int)
     if isinteger(ν) && real(ν) > 0
         return real(ν) < (typemax(Int)>>2) ? En_expand_origin_posint(Int(real(ν)), z, niter) : En_expand_origin_posint(real(ν), z, niter)
     else
-        return En_expand_origin_general(ν, z, niter)
+        # `En_expand_origin_general` takes both arguments at the same precision
+        T = typeof(one(real(z)))
+        return En_expand_origin_general(ν isa Real ? convert(T, ν) : convert(Complex{T}, ν), z, niter)
     end
 end
 
 # can find imaginary part of E_ν(x) for x on negative real axis analytically
 # https://functions.wolfram.com/GammaBetaErf/ExpIntegralE/04/05/01/0003/
-function En_imagbranchcut(ν::Number, z::Number)
+function En_imagbranchcut(ν::Union{T,Complex{T}}, z::Union{T,Complex{T}}) where {T<:AbstractFloat}
     a = real(z)
-    e1 = exp(oftype(a, π) * imag(ν))
+    e1 = exp(π * imag(ν))
     e2 = Complex(cospi(real(ν)), -sinpi(real(ν)))
     lgamma, lgammasign = ν isa Real ? logabsgamma(ν) : (loggamma(ν), 1)
     return -2 * lgammasign * e1 * π * e2 * exp((ν-1)*log(complex(a)) - lgamma) * im
@@ -490,7 +535,9 @@ function _expint(ν::Number, z::Number, niter::Int=1000, ::Val{expscaled}=Val{fa
 
         # handle branch cut
         if imz == 0
-            bc = En_imagbranchcut(ν, z)
+            # `En_imagbranchcut` takes both arguments at the same precision
+            νc = ν isa Real ? convert(real(typeof(z)), ν) : convert(complex(real(typeof(z))), ν)
+            bc = En_imagbranchcut(νc, z)
             bit = !signbit(imag(z))
             sign = bit ? 1 : -1
             if isreal(ν)

--- a/src/gamma_inc.jl
+++ b/src/gamma_inc.jl
@@ -1099,7 +1099,8 @@ Returns the upper incomplete gamma function
 ```math
 \Gamma(a,x) = \int_x^\infty t^{a-1} e^{-t} \mathrm{d}t
 ```
-supporting arbitrary real or complex `a` and `x`.
+for real or complex `a` and `x` of `Float16`, `Float32` or `Float64` precision, and for
+real `BigFloat` arguments with `x >= 0`.
 
 (The ordinary gamma function [`gamma(x)`](@ref) corresponds to ``\Gamma(a) = \Gamma(a,0)``.
 See also the [`gamma_inc`](@ref) function to compute both the upper and lower
@@ -1110,44 +1111,23 @@ External links:
 [Wikipedia](https://en.wikipedia.org/wiki/Incomplete_gamma_function)
 """
 gamma(a::Number,  x::Number) = _gamma(promotereal(float(a), float(x))...)
-gamma(a::Integer, x::Number) = _gamma(a, float(x))
 
-function _gamma(a::Number, x::Number)
+function _gamma(a::Union{T,Complex{T}}, x::Union{T,Complex{T}}) where {T<:Union{Float16,Float32,Float64}}
+    # Γ(a,x) is not real for x < 0, except for integer a, and is not supported there
+    x isa Real && x < 0 && throw(DomainError((a, x), "gamma will only return a complex result if called with a complex argument"))
     if a isa Real && x isa Real && !isfinite(a*x)
-        if isinf(x) && isfinite(a)
-            if x > 0 # == +Inf
-                return one(a)*zero(x)
-            elseif a > 0 && isinteger(a) # x == -Inf
-                return one(a)*x # -Inf
-            end
+        if isinf(x) && isfinite(a) # x == +Inf
+            return one(a)*zero(x)
         elseif isinf(a) && isfinite(x)
-            if a > 0
-                if x ≥ 0
-                    return a*one(x) # +Inf
-                else
-                    throw(DomainError((a, x), "gamma will only return a complex result if called with a complex argument"))
-                end
-            elseif a < 0
-                return zero(a)*one(x)
-            end
+            return a > 0 ? a*one(x) : zero(a)*one(x) # +Inf or 0
         end
     end
     return iszero(x) ? gamma(one(x)*a) : x^a * expint(1 - a, x)
 end
 
-_gamma(a::Integer, x::BigFloat) = _gamma_big(a, x)
-_gamma(a::BigInt, x::Real) = _gamma_big(a, x)
-_gamma(a::BigInt, x::BigFloat) = _gamma_big(a, x)
-_gamma(a::BigFloat,x::BigFloat) = _gamma_big(a, x)
-function _gamma_big(a::Real,x::Real)
-    if x < 0
-        # MPFR returns NaN in this case
-        if isinteger(a) && a > 0
-            return invoke(_gamma, Tuple{Number,Number}, a, BigFloat(x))
-        else
-            throw(DomainError((a, x), "gamma will only return a complex result if called with a complex argument"))
-        end
-    end
+function _gamma(a::BigFloat, x::BigFloat)
+    # MPFR returns NaN for x < 0, where Γ(a,x) is complex unless a is an integer
+    x < 0 && throw(DomainError((a, x), "gamma will only return a complex result if called with a complex argument"))
     z = BigFloat()
     ccall((:mpfr_gamma_inc, :libmpfr), Int32, (Ref{BigFloat}, Ref{BigFloat}, Ref{BigFloat}, Int32), z, a, x, ROUNDING_MODE[])
     return z
@@ -1160,7 +1140,7 @@ Returns the log of the upper incomplete gamma function [`gamma(a,x)`](@ref):
 ```math
 \log \Gamma(a,x) = \log \int_x^\infty t^{a-1} e^{-t} \mathrm{d}t
 ```
-supporting arbitrary real or complex `a` and `x`.
+for real or complex `a` and `x` of `Float16`, `Float32` or `Float64` precision.
 
 If `a` and/or `x` is complex, then `exp(loggamma(a,x))` matches `gamma(a,x)` (up to floating-point error),
 but `loggamma(a,x)` may differ from `log(gamma(a,x))` by an integer multiple of ``2\pi i``
@@ -1169,28 +1149,17 @@ but `loggamma(a,x)` may differ from `log(gamma(a,x))` by an integer multiple of 
 See also [`loggamma(x)`](@ref).
 """
 loggamma(a::Number, x::Number) = _loggamma(promotereal(float(a), float(x))...)
-loggamma(a::Integer, x::Number) = _loggamma(a, float(x))
-function _loggamma(a::Number, x::Number)
+function _loggamma(a::Union{T,Complex{T}}, x::Union{T,Complex{T}}) where {T<:Union{Float16,Float32,Float64}}
+    # as for `gamma(a,x)`, x < 0 is not supported
+    x isa Real && x < 0 && throw(DomainError((a, x), "loggamma will only return a complex result if called with a complex argument"))
     if a isa Real && x isa Real && !isfinite(a*x)
-        if isinf(x) && isfinite(a)
-            if x > 0 # == +Inf
-                return -one(a)*x
-            elseif x < 0
-                throw(DomainError((a, x), "loggamma will only return a complex result if called with a complex argument"))
-            end
+        if isinf(x) && isfinite(a) # x == +Inf
+            return -one(a)*x
         elseif isinf(a) && isfinite(x)
-            if a > 0 && x ≥ 0
-                return a*one(x) # +Inf
-            elseif a < 0
-                return a*one(x) # -Inf
-            end
+            return a*one(x) # +Inf or -Inf
         end
     end
     # from gamma(a,x) = x^a * expintx(1-a, x) * exp(-x):
     iszero(x) && return loggamma(one(x)*a)
-    if x isa Real && x < 0 && a isa Integer && isodd(a)
-        # minus signs in expintx and x^a may cancel
-        return a*log(-x) + log(-expintx(1-a, x)) - x
-    end
     return a*log(x) + log(expintx(1 - a, x)) - x
 end

--- a/test/expint.jl
+++ b/test/expint.jl
@@ -159,8 +159,8 @@ using Base.MathConstants
                 @test Γ + cf*exp(-x) ≈ y
             end
             # type stability
-            @test @inferred(SpecialFunctions.En_cf_gamma(1, 1.0 + 2.1im, 1000)) isa Tuple{ComplexF64,ComplexF64,Int}
-            @test @inferred(SpecialFunctions.En_cf_gamma(1, 1.0f0, 1000)) isa Tuple{Float32,Float32,Int}
+            @test @inferred(SpecialFunctions.En_cf_gamma(1.0, 1.0 + 2.1im, 1000)) isa Tuple{ComplexF64,ComplexF64,Int}
+            @test @inferred(SpecialFunctions.En_cf_gamma(1.0f0, 1.0f0, 1000)) isa Tuple{Float32,Float32,Int}
         end
         @testset "En_expand_origin" begin
             for (x, y) in zip(xs, ys)

--- a/test/expint.jl
+++ b/test/expint.jl
@@ -282,3 +282,15 @@ end
     @test expint(2+3im, 1.5) ≈ 0.041610033532947484 - 0.039327583535599371im rtol = 1e-12
     @test expint(3+1im, 2.0) ≈ 0.029047898068379150 - 0.0058773000832093846im rtol = 1e-12
 end
+
+@testset "expint continued fraction" begin
+    # These points have abs2(z) > 9, so they use the continued fraction.
+    # The reference is MPFR's incomplete gamma.
+    setprecision(BigFloat, 256) do
+        @testset "ν = $ν, z = $z" for (ν, z) in ((2, 4.15), (2, 12.0), (2, 31.81),
+                                                 (2.5, 5.91), (2.5, 33.75), (2.5, 60.0),
+                                                 (3, 35.53), (5, 41.49), (10, 35.95))
+            @test expint(ν, z) ≈ Float64(expint(BigFloat(ν), BigFloat(z))) rtol = 50*eps(Float64)
+        end
+    end
+end

--- a/test/expint.jl
+++ b/test/expint.jl
@@ -245,3 +245,40 @@ expinti_real(x) = invoke(expinti, Tuple{Real}, x)
         end
     end
 end
+
+@testset "expint near a positive integer order" begin
+    # `Float16` used to be excluded from the near-pole correction and returned 0
+    @testset "$T" for T in (Float16, Float32, Float64)
+        z = T(3)/2
+        for ν in (nextfloat(T(3)), nextfloat(T(3), 2), prevfloat(T(3)))
+            @test expint(ν, z) ≈ T(setprecision(BigFloat, 256) do
+                expint(BigFloat(ν), BigFloat(z))
+            end) rtol = 100*eps(T)   # the δ-series is a few tens of ulps off this close in
+        end
+    end
+
+    # real `BigFloat` is delegated to MPFR's incomplete gamma, which has no
+    # cancellation here; the series it replaced was accurate to about 1e-17
+    setprecision(BigFloat, 256) do
+        ν = 3 + BigFloat(10)^-20
+        z = BigFloat(3)/2
+        hi = setprecision(BigFloat, 1024) do
+            BigFloat(expint(3 + BigFloat(10)^-20, BigFloat(3)/2))
+        end
+        @test isapprox(expint(ν, z), hi; rtol = 1e-70)
+    end
+
+    # complex `BigFloat` has neither: `polygamma` is not defined for it and MPFR is
+    # real only
+    setprecision(BigFloat, 256) do
+        @test_throws MethodError expint(Complex{BigFloat}(5//2, 1), Complex{BigFloat}(3//2, 0))
+    end
+
+    # a complex order is close to a pole of `Γ(1-ν)` only if its imaginary part is small
+    # too, so these three are far from one and take the cancelling form. `abs2(z) < 9`,
+    # so they use the series rather than the continued fraction. Reference values from
+    # the series at 500 bits.
+    @test expint(1+1im, 2.5) ≈ 0.023604664164557882 - 0.0059967105214225527im rtol = 1e-12
+    @test expint(2+3im, 1.5) ≈ 0.041610033532947484 - 0.039327583535599371im rtol = 1e-12
+    @test expint(3+1im, 2.0) ≈ 0.029047898068379150 - 0.0058773000832093846im rtol = 1e-12
+end

--- a/test/gamma_inc.jl
+++ b/test/gamma_inc.jl
@@ -316,17 +316,20 @@ double(x::Complex) = ComplexF64(x)
         for a in Any[0:0.4:3; 1:3], x in 0:0.2:2
             @test gamma(a,x) ≈ gamma(big(a),big(x))
         end
+        # x < 0 is not supported: Γ(a,x) is not real there except for integer a
         @test_throws DomainError gamma(-2.2, -1.3)
+        @test_throws DomainError gamma(2, -1.3)
+        @test_throws DomainError gamma(2, big"-1.3")
+        @test_throws DomainError gamma(30, -1e2)
+        @test_throws DomainError gamma(30, big"-1e2")
         for (a,x, exact) in (
             (2, big"+1.3", big"0.6268231239782289871813662853957039889809398944861850589869804057956189274569818"),
-            (2, big"-1.3", big"-1.100789000285773266137246974803445875429455665367265440176867948378982424804222"),
             (big"2.2", big"1.3", big"0.7550934853735524106456916078787596171599416239996064979513848803118671763945577"),
             (big"-2.2", big"1.3", big"0.03938564959393195337328006806473296774233286427565465045140458665248322893076784"),
             (big"-2.2", big"-1.3"+0im, Complex(big"0.1688350167695890519002747177035271528716667324397453142169971691104641885370081", big"-1.724677939954414412829215929952389349929001266936564849801773346878175589599461")),
             (2, big"1.3"+2im, Complex(big"0.2347744561498965806069446787000456827042253434143074251879541754828136789074293", big"-0.7967951407674886396960561446265346226800340382780520672369163777061700801594228")),
             (big"2.2", big"1.3"+2im, Complex(big"0.4226969694490623767886715572749155659150206342283251276656790859161308520476838", big"-0.9507541450333763666696561254491461255244463810462729822382144498284499948680099")),
             (big"2.2"-2im, big"1.3"+2im, Complex(big"-3.858698824275578861673404086439928163791926530897603434146764316225759116935376", big"0.2105970967650200831829566202893410569725743566037534990454186505024476246014339")),
-            (30, big"-1e2", big"-2.080142496354742431762923569133534773079637504483999408076147454085194055640495e+101"),
             )
             if !(exact isa Complex) # we don't yet have a Complex{BigFloat} gamma function
                 @test gamma(a, x) ≈ exact atol=eps(abs(exact))*1000
@@ -334,20 +337,21 @@ double(x::Complex) = ComplexF64(x)
             @test gamma(double(a), double(x)) ≈ double(exact) rtol=1e-13
         end
     end
-    @test gamma(30, big(-1000)) ≈ big"-1.914496653187781420578078670260160511219745144309147121829045802464973219500799e+521" rtol=1e-70
-    @test gamma(30, -1000) == -Inf
+    @test_throws DomainError gamma(30, big(-1000))
+    @test_throws DomainError gamma(30, -1000)
     @test gamma(Inf, 51.2) == Inf
-    @test gamma(-Inf, -51.2) == 0.0
+    @test_throws DomainError gamma(-Inf, -51.2)
     @test_throws DomainError gamma(Inf, -51.2)
     @test gamma(2.3, Inf) == 0.0
-    @test gamma(2, -Inf) == -Inf
+    @test_throws DomainError gamma(2, -Inf)
     @test_throws DomainError gamma(2.2, -Inf)
 end
 
 @testset "upper incomplete gamma function logarithm" begin
-    for (a,z) in ((3,5), (3,-5), (3,5+4im), (3,-5+4im), (3,5-4im), (-3,5+4im), (-3,-5+4im))
+    for (a,z) in ((3,5), (3,5+4im), (3,-5+4im), (3,5-4im), (-3,5+4im), (-3,-5+4im))
         @test exp(loggamma(a,z)) ≈ gamma(a,z) rtol=1e-13
     end
+    @test_throws DomainError loggamma(3, -5)
     @test loggamma(50, 1e7) ≅ -9.9992102133082030308153473164868727954977460876571275797855e6
     @test real(loggamma(50, 1e7 + 1e8im)) ≅ -9.999097142860392e6
     @test cis(imag(loggamma(50, 1e7 + 1e8im))) ≈ cis(1.0275220422549918) rtol=1e-8
@@ -360,7 +364,7 @@ end
     @test loggamma(-Inf, 3.2) == -Inf
     @test_throws DomainError loggamma(Inf, -3.2)
     @test loggamma(117.3, 0) == loggamma(117.3)
-    @test loggamma(7, -300.2) ≅ log(gamma(7, -300.2))
+    @test_throws DomainError loggamma(7, -300.2)
     @test_throws DomainError loggamma(6, -3.2)
 end
 

--- a/test/type_stability.jl
+++ b/test/type_stability.jl
@@ -230,9 +230,11 @@ end
     @test @inferred(besselj0(big(1))) isa BigFloat
     @test @inferred(besselj(2, big(1))) isa BigFloat
     @test @inferred(expinti(big(2))) isa BigFloat
-    @test @inferred(loggamma(big(2), big(3))) isa BigFloat
     @test @inferred(expint(big(2), big(3)/2)) isa BigFloat
-    @test @inferred(expintx(big(2), big(3)/2)) isa BigFloat
+    # `loggamma(a, x)` and `expintx(ν, z)` have no `BigFloat` route: `_loggamma` is
+    # restricted to the hardware floats, and MPFR has no scaled incomplete gamma
+    @test_throws MethodError loggamma(big(2), big(3))
+    @test_throws MethodError expintx(big(2), big(3)/2)
     # `expint(x::BigFloat)` is inferred as `Union{Float64,BigFloat}`
     @test @inferred(expint(big(1))) isa BigFloat broken = true
     # `airyai` lacks the `f(x::Real) = f(float(x))` promotion that `besselj0` has, so a

--- a/test/type_stability.jl
+++ b/test/type_stability.jl
@@ -62,11 +62,9 @@ end
     @test @inferred(logbeta(C(3, 1), C(2, 1))) isa C
 end
 
-# `gamma(a, x)` and `loggamma(a, x)` are computed via `expint` for non-positive-integer
-# `a`, which widens a `Float16`/`Float32` argument to `Float64`
 @testset "incomplete gamma ($T)" for T in (Float16, Float32, Float64)
-    @test @inferred(gamma(T(2), T(3))) isa T broken = T !== Float64
-    @test @inferred(loggamma(T(2), T(3))) isa T broken = T !== Float64
+    @test @inferred(gamma(T(2), T(3))) isa T
+    @test @inferred(loggamma(T(2), T(3))) isa T
 end
 
 @testset "incomplete gamma and beta ($T)" for T in (Float16, Float32, Float64)
@@ -114,16 +112,15 @@ end
     @test @inferred(expintx(C(1, 1))) isa C
 end
 
-# `expint(ν, z)` widens `Float16`/`Float32` arguments to `Float64` on several paths
 @testset "exponential integrals with an order ($T)" for T in (Float16, Float32, Float64)
-    @test @inferred(expint(2, T(3))) isa T broken = T !== Float64
-    @test @inferred(expint(T(3)/2, T(3))) isa T broken = T !== Float64
-    @test @inferred(expintx(2, T(3))) isa T broken = T !== Float64
+    @test @inferred(expint(2, T(3))) isa T
+    @test @inferred(expint(T(3)/2, T(3))) isa T
+    @test @inferred(expintx(2, T(3))) isa T
 end
 
 @testset "exponential integrals with an order ($C)" for C in (ComplexF32, ComplexF64)
-    @test @inferred(expint(2, C(1, 1))) isa C broken = C !== ComplexF64
-    @test @inferred(expintx(2, C(1, 1))) isa C broken = C !== ComplexF64
+    @test @inferred(expint(2, C(1, 1))) isa C
+    @test @inferred(expintx(2, C(1, 1))) isa C
 end
 
 @testset "Bessel functions of order 0 and 1 ($T)" for T in (Float16, Float32, Float64)
@@ -230,10 +227,10 @@ end
     @test @inferred(gamma(big(3)/2)) isa BigFloat
     @test @inferred(zeta(big(3))) isa BigFloat
     @test @inferred(gamma(big(2), big(3))) isa BigFloat
-    @test @inferred(loggamma(big(2), big(3))) isa BigFloat
     @test @inferred(besselj0(big(1))) isa BigFloat
     @test @inferred(besselj(2, big(1))) isa BigFloat
     @test @inferred(expinti(big(2))) isa BigFloat
+    @test @inferred(loggamma(big(2), big(3))) isa BigFloat
     @test @inferred(expint(big(2), big(3)/2)) isa BigFloat
     @test @inferred(expintx(big(2), big(3)/2)) isa BigFloat
     # `expint(x::BigFloat)` is inferred as `Union{Float64,BigFloat}`


### PR DESCRIPTION
**Stacked on #549** — please merge that one first; this PR targets its branch and GitHub will retarget it to `master` afterwards. It flips the twelve `expint`/`gamma(a, x)` entries in the sweep from `@test_broken` to `@test`.

## The problem

The internal helpers took `(n::Real, z::Number)` and `(ν::Number, z::Number)`, so an order and an argument of unrelated precisions met inside them and every operation adopted whichever operand it touched: `loggamma(n+1)`, `logabsgamma(ν)` and `polygamma` followed the order — `Float64` for an `Integer` one — while the rest followed the argument. `_expint` promoted `z` against `ν` but deliberately left `ν` alone, so the mismatch was the normal case, not an edge case.

Consequences: `expint(::Float32, ::Float32)` and `gamma(::Float32, ::Float32)` inferred `Union{Float32,Float64}` (what [#520](https://github.com/JuliaMath/SpecialFunctions.jl/pull/520) ran into), a `BigFloat` result on the negative real axis was capped at `Float64` accuracy, and `Float16` returned `0.0` near a positive integer order.

## The change

Every internal helper takes its arguments at one precision — `Union{T,Complex{T}}` with `T` one of `Float16`, `Float32`, `Float64` — and the promotion happens once, at the public entry. No promoting methods on the helpers, so a mismatch is a `MethodError` at the call site rather than a silent mixed-precision computation.

* An integer order now adopts the argument's precision instead of dragging the computation to `Float64`.
* `En_safe_expfact(n::T, z::T)` / `(n::T, z::Complex{T})`. `isodd` works on floats, so `Int(n)`, the `n <= typemax(Int)` guard and the `(-1)^n` fallback are gone, and with them the `typemax(Int)` dispatch in `En_expand_origin`. The switch to the closed form moves from `n < 100` to `n < 12`: measured, the product form is the more accurate of the two everywhere, and above `n ≈ 12` the term is negligible next to the sums the callers add it to, in every precision.
* `En_expand_origin_general` keeps the near-pole correction in a separate `En_origin_pole_series`, defined only for the precisions its δ⁴ truncation can serve, and triggered by `abs(δ) < eps(T)^(1/6)/2` instead of a cancellation ratio: the series error is `O(δ⁵)` and the cancelling form loses accuracy like `eps/δ`, so the two meet at `δ ~ eps(T)^(1/6)`. The old ratio saturated at ~0.036 for δ ≥ 0.1 and could not express the `Float16` boundary. Its `π^2`/`π^4` constants are evaluated in `T`.
* `En_safeexpmult` and `En_imagbranchcut` are split into real and complex methods rather than branching on `isa`, and use `sincospi`.
* The unreachable `En_safe_gamma_term(::Integer, ::Real)` method and the `float`/`promote`/`oftype` shims inside the helpers are gone.

## Incomplete gamma

`gamma(a, x)` and `loggamma(a, x)` now throw `DomainError` for real `x < 0`, where the value is complex except at integer `a`. **This is a breaking change**: `gamma(2, -1.3)` returned `-1.1008` and now throws, and the negative-`x` assertions in `test/gamma_inc.jl` — including the hand-computed `big"-1.1007890…"` and `big"-2.0801…e101"` references — become `@test_throws`.

The rationale is that both available kernels reject it anyway: MPFR's `mpfr_gamma_inc` returns `NaN` for `x < 0`, and NSWC's `GRATIO` documents *"IT IS ASSUMED THAT A AND X ARE NONNEGATIVE"*. The old support came from `_gamma_big` routing negative `x` with integer `a` through `x^a * expint(1-a, x)`, i.e. through the very function this PR is fixing.

So `_gamma_big` is deleted along with its four `_gamma` methods and the separate `gamma(a::Integer, x)`; the `BigFloat` method is now a plain `mpfr_gamma_inc` ccall. Only `x` is restricted, not `a`: `expint` delegates as `gamma(1-ν, z)`, so the first argument is negative whenever `ν > 1`, and `mpfr_gamma_inc` accepts a negative first argument — it is only `x < 0` that returns `NaN`.

## Fixes

**`Float16` near a positive integer order returned zero**, because the old `real(ν+z) isa Union{Float64,Float32}` guard excluded it and the fallback then adds `blowup ≈ 1/δ ≈ 500` to `sumterm ≈ 0.057` — `Float16`'s spacing at 500 is 0.5, so the sum is annihilated:

```julia
julia> expint(Float16(3.002), Float16(1.5))     # true value 0.0567
Float16(0.0)                                    # master
Float16(0.05627)                                # this PR
```

`Float16` was never a numerical problem there: at its spacing near a pole the truncation error is `δ⁵ ≈ 3e-14`, eleven orders below `eps(Float16)`.

**Type stability**, all now concrete: `expint(::Int,::Float16)`, `expint(::Int,::Float32)`, `expint(::Float32,::Float32)`, `expint(::Int,::ComplexF32)`, `expint(::Float32,::ComplexF32)`, `gamma(::Float32,::Float32)`.

**`BigFloat` on the negative real axis** — from the signature, not a conversion: `expint(5, big(-4)+0im)` goes from 53 to 244 correct bits of 256, `expint(9, …)` from 50 to 245.

**Real `BigFloat` near a positive integer order** is delegated to MPFR via `E_ν(z) = z^(ν-1) Γ(1-ν, z)`, which has no cancellation there: 258 correct bits of 256, against 119 for the series at δ = 1e-40. Validated against an independent reference (the series at 4096 bits), not against itself.

**`expintx` has no `BigFloat` method any more.** MPFR has no *scaled* incomplete gamma, and building `exp(z)·E_ν(z)` from the unscaled value would defeat the point of the scaled function — it forms the underflowing quantity and multiplies by an overflowing one. Complex `BigFloat` has no route either (`polygamma` is undefined for it, MPFR is real only, and `gamma(a,x)` for complex arguments routes back through `expint`), so it throws rather than returning a badly cancelled value. A follow-up can restore both with guard bits: recomputing at `precision + ceil(log2(1/abs(δ))) + 10` and rounding back gives full precision.

## Also

`JET.report_package` loses the `_polygamma(::Int64, ::BigFloat)` finding, since the correction no longer reaches `polygamma` with a `BigInt`-derived order.

Full suite passes on 1.10, 1.12 and 1.13-rc3. New tests cover the near-pole values for all three hardware precisions, the `BigFloat` delegation, and the complex `BigFloat` error.

## Known limitation, not addressed here

The origin series and the continued fraction lose accuracy to cancellation independently of any of this: at `x = 2.94` the two terms are 119–255× the result, so ~8 bits go structurally. It is invisible at `Float64` but not at `Float32`, where it makes `expint(1, x)` and `expint(x)` disagree by up to 439 ulps (the one-argument entry evaluates `E₁` in `Float64` and rounds). Filing separately.

---

*Prepared by Claude Code on behalf of @andreasnoack; the investigation and the text above are Claude's.*
