### PR TITLE
Promote the Bessel order against the argument

### DIFF
--- a/src/bessel.jl
+++ b/src/bessel.jl
@@ -336,7 +336,9 @@ function besselh(nu::Float64, k::Integer, z::Complex{Float64})
     return _besselh(nu,Int32(k),z,Int32(1))
 end
 
-function besselh(nu::Float64, k::Integer, x::Float64)
+# restricted to the hardware floats: `besselj`/`bessely` support `BigFloat` for integer
+# orders only, so a `BigFloat` method here would work for some orders and not others
+function besselh(nu::T, k::Integer, x::T) where {T<:Union{Float16,Float32,Float64}}
     # Given that x is real, Jnu(x) and Ynu(x) are also real.
     if k == 1
         return complex(besselj(nu, x), bessely(nu, x))
@@ -415,6 +417,7 @@ end
 
 besselj(nu::Cint, x::Float64) = ccall((:jn, libopenlibm), Float64, (Cint, Float64), nu, x)
 besselj(nu::Cint, x::Float32) = ccall((:jnf, libopenlibm), Float32, (Cint, Float32), nu, x)
+besselj(nu::Cint, x::Float16) = Float16(besselj(nu, Float32(x)))
 
 
 function besseljx(nu::Float64, z::Complex{Float64})
@@ -445,6 +448,7 @@ function bessely(nu::Cint, x::Float32)
     end
     ccall((:ynf, libopenlibm), Float32, (Cint, Float32), nu, x)
 end
+bessely(nu::Cint, x::Float16) = Float16(bessely(nu, Float32(x)))
 
 function bessely(nu::Float64, z::Complex{Float64})
     if nu < 0
@@ -480,7 +484,7 @@ function besseli(nu::Real, x::AbstractFloat)
     if x < 0 && !isinteger(nu)
         throw(DomainError(x, "`x` must be nonnegative and `nu` must be an integer."))
     end
-    real(besseli(float(nu), complex(x)))
+    real(besseli(nu, complex(x)))
 end
 
 @doc raw"""
@@ -501,7 +505,7 @@ function besselix(nu::Real, x::AbstractFloat)
     if x < 0 && !isinteger(nu)
         throw(DomainError(x, "`x` must be nonnegative and `nu` must be an integer."))
     end
-    real(besselix(float(nu), complex(x)))
+    real(besselix(nu, complex(x)))
 end
 
 @doc raw"""
@@ -526,7 +530,7 @@ function besselj(nu::Real, x::AbstractFloat)
     elseif x < 0
         throw(DomainError(x, "`x` must be nonnegative."))
     end
-    real(besselj(float(nu), complex(x)))
+    real(besselj(nu, complex(x)))
 end
 
 @doc raw"""
@@ -547,7 +551,7 @@ function besseljx(nu::Real, x::AbstractFloat)
     if x < 0 && !isinteger(nu)
         throw(DomainError(x, "`x` must be nonnegative and `nu` must be an integer."))
     end
-    real(besseljx(float(nu), complex(x)))
+    real(besseljx(nu, complex(x)))
 end
 
 @doc raw"""
@@ -570,7 +574,7 @@ function besselk(nu::Real, x::AbstractFloat)
     elseif x == 0
         return oftype(x, Inf)
     end
-    real(besselk(float(nu), complex(x)))
+    real(besselk(nu, complex(x)))
 end
 
 @doc raw"""
@@ -593,7 +597,7 @@ function besselkx(nu::Real, x::AbstractFloat)
     elseif x == 0
         return oftype(x, Inf)
     end
-    real(besselkx(float(nu), complex(x)))
+    real(besselkx(nu, complex(x)))
 end
 
 """
@@ -613,7 +617,7 @@ function bessely(nu::Real, x::AbstractFloat)
     elseif isinteger(nu) && typemin(Cint) <= nu <= typemax(Cint)
         return bessely(Cint(nu), x)
     end
-    real(bessely(float(nu), complex(x)))
+    real(bessely(nu, complex(x)))
 end
 
 """
@@ -632,17 +636,16 @@ function besselyx(nu::Real, x::AbstractFloat)
     if x < 0
         throw(DomainError(x, "`x` must be nonnegative."))
     end
-    real(besselyx(float(nu), complex(x)))
+    real(besselyx(nu, complex(x)))
 end
 
 for f in ("i", "ix", "j", "jx", "k", "kx", "y", "yx")
     bfn = Symbol("bessel", f)
     @eval begin
         $bfn(nu::Real, x::Real) = $bfn(nu, float(x))
-        function $bfn(nu::Real, z::Complex)
-            Tf = promote_type(float(typeof(nu)),float(typeof(real(z))))
-            $bfn(Tf(nu), Complex{Tf}(z))
-        end
+        # promote `nu` against `z` so that an integer or rational order adopts the
+        # precision of the argument instead of forcing `Float64`
+        $bfn(nu::Real, z::Complex) = $bfn(promotereal(nu, float(z))...)
         $bfn(nu::Float16, x::Complex{Float16}) = Complex{Float16}($bfn(Float32(nu), Complex{Float32}(x)))
         $bfn(nu::Float32, x::Complex{Float32}) = Complex{Float32}($bfn(Float64(nu), Complex{Float64}(x)))
         $bfn(k::T, z::Complex{T}) where {T<:AbstractFloat} = throw(MethodError($bfn,(k,z)))
@@ -653,20 +656,22 @@ end
 for bfn in (:besselh, :besselhx)
     @eval begin
         $bfn(nu, z) = $bfn(nu, 1, z)
-        $bfn(nu::Real, k::Integer, x::Real) = $bfn(float(nu), k, float(x))
-        $bfn(nu::AbstractFloat, k::Integer, x::AbstractFloat) = $bfn(float(nu), k, complex(x))
+        # promote `nu` against `x` so that an integer or rational order adopts the
+        # precision of the argument instead of forcing `Float64`
+        function $bfn(nu::Real, k::Integer, x::Real)
+            nu, x = promotereal(nu, float(x))
+            return $bfn(nu, k, x)
+        end
+        $bfn(nu::T, k::Integer, x::T) where {T<:AbstractFloat} = $bfn(nu, k, complex(x))
         function $bfn(nu::Real, k::Integer, z::Complex)
-            Tf = promote_type(float(typeof(nu)),float(typeof(real(z))))
-            $bfn(Tf(nu), k, Complex{Tf}(z))
+            nu, z = promotereal(nu, float(z))
+            $bfn(nu, k, z)
         end
         $bfn(nu::Float16, k::Integer, x::Complex{Float16}) = Complex{Float16}($bfn(Float32(nu), k, Complex{Float32}(x)))
         $bfn(nu::Float32, k::Integer, x::Complex{Float32}) = Complex{Float32}($bfn(Float64(nu), k, Complex{Float64}(x)))
         $bfn(nu::T, k::Integer, z::Complex{T}) where {T<:AbstractFloat} = throw(MethodError($bfn,(nu,k,z)))
     end
 end
-
-besselh(nu::Float16, k::Integer, x::Float16) = Complex{Float16}(besselh(Float32(nu), k, Float32(x)))
-besselh(nu::Float32, k::Integer, x::Float32) = Complex{Float32}(besselh(Float64(nu), k, Float64(x)))
 
 """
     besselj0(x)
@@ -763,12 +768,14 @@ end
 Spherical Bessel function of the first kind at order `nu`, ``j_ν(x)``. This is the non-singular
 solution to the radial part of the Helmholz equation in spherical coordinates.
 """
-function sphericalbesselj(nu, x::T) where {T}
+sphericalbesselj(nu::Real, x::Number) = sphericalbesselj(promotereal(nu, float(x))...)
+
+function sphericalbesselj(nu::T, x::Union{T,Complex{T}}) where {T<:AbstractFloat}
     besselj_nuhalf_x = besselj(nu + one(nu)/2, x)
-    if abs(x) ≤ sqrt(eps(real(zero(besselj_nuhalf_x))))
-        nu == 0 ? one(besselj_nuhalf_x) : zero(besselj_nuhalf_x)
+    if abs(x) ≤ sqrt(eps(zero(T)))
+        return nu == 0 ? one(besselj_nuhalf_x) : zero(besselj_nuhalf_x)
     else
-        √((float(T))(π)/2x) * besselj_nuhalf_x
+        return √(T(π)/2x) * besselj_nuhalf_x
     end
 end
 
@@ -779,7 +786,10 @@ Spherical Bessel function of the second kind at order `nu`, ``y_ν(x)``. This is
 the singular solution to the radial part of the Helmholz equation in spherical
 coordinates. Sometimes known as a spherical Neumann function.
 """
-sphericalbessely(nu, x::T) where {T} = √((float(T))(π)/2x) * bessely(nu + one(nu)/2, x)
+sphericalbessely(nu::Real, x::Number) = sphericalbessely(promotereal(nu, float(x))...)
+
+sphericalbessely(nu::T, x::Union{T,Complex{T}}) where {T<:AbstractFloat} =
+    √(T(π)/2x) * bessely(nu + one(nu)/2, x)
 
 """
     hankelh1(nu, x)

--- a/test/type_stability.jl
+++ b/test/type_stability.jl
@@ -5,11 +5,7 @@
 # argument must not be widened. `@inferred(f(x)) isa T` checks both properties at
 # once, since a method can be perfectly inferrable and still return the wrong type.
 #
-# The entries marked `broken` are the cases that get this wrong today. Most of them are
-# in the Bessel family, where the fall-through in `besselj(nu::Real, x::AbstractFloat)`
-# and its siblings promotes the order with `float(nu)` and drags the argument up with
-# it; that fall-through also has no method to land on for a `Float16` argument, hence
-# https://github.com/JuliaMath/SpecialFunctions.jl/issues/547.
+# The entries marked `broken` are the cases that get this wrong today.
 
 @testset "error functions ($T)" for T in (Float16, Float32, Float64)
     @test @inferred(erf(T(1))) isa T
@@ -135,48 +131,45 @@ end
 end
 
 @testset "Bessel functions of general order ($T)" for T in (Float16, Float32, Float64)
-    @test @inferred(besselj(T(3)/2, T(1))) isa T broken = T === Float16
-    @test @inferred(bessely(T(3)/2, T(1))) isa T broken = T === Float16
-    @test @inferred(besseli(2, T(1))) isa T broken = T !== Float64
-    @test @inferred(besselk(2, T(1))) isa T broken = T !== Float64
-    @test @inferred(besseljx(2, T(1))) isa T broken = T !== Float64
-    @test @inferred(besselyx(2, T(1))) isa T broken = T !== Float64
-    @test @inferred(besselix(2, T(1))) isa T broken = T !== Float64
-    @test @inferred(besselkx(2, T(1))) isa T broken = T !== Float64
-    @test @inferred(sphericalbesselj(2, T(1))) isa T broken = T !== Float64
-    @test @inferred(sphericalbessely(2, T(1))) isa T broken = T !== Float64
-    @test @inferred(hankelh1(2, T(1))) isa Complex{T} broken = T !== Float64
-    @test @inferred(hankelh2(2, T(1))) isa Complex{T} broken = T !== Float64
+    @test @inferred(besselj(T(3)/2, T(1))) isa T
+    @test @inferred(bessely(T(3)/2, T(1))) isa T
+    @test @inferred(besseli(2, T(1))) isa T
+    @test @inferred(besselk(2, T(1))) isa T
+    @test @inferred(besseljx(2, T(1))) isa T
+    @test @inferred(besselyx(2, T(1))) isa T
+    @test @inferred(besselix(2, T(1))) isa T
+    @test @inferred(besselkx(2, T(1))) isa T
+    @test @inferred(sphericalbesselj(2, T(1))) isa T
+    @test @inferred(sphericalbessely(2, T(1))) isa T
+    @test @inferred(hankelh1(2, T(1))) isa Complex{T}
+    @test @inferred(hankelh2(2, T(1))) isa Complex{T}
 end
 
-# `Float16` is left out: `besselj(2, Float16(1))` and `bessely(2, Float16(1))` recurse
-# until the stack overflows, which would leave the test process corrupted (#547)
-@testset "Bessel functions of integer order ($T)" for T in (Float32, Float64)
-    @test @inferred(besselj(2, T(1))) isa T broken = T !== Float64
-    @test @inferred(bessely(2, T(1))) isa T broken = T !== Float64
+@testset "Bessel functions of integer order ($T)" for T in (Float16, Float32, Float64)
+    @test @inferred(besselj(2, T(1))) isa T
+    @test @inferred(bessely(2, T(1))) isa T
 end
 
 @testset "Bessel functions of general order ($C)" for C in (ComplexF32, ComplexF64)
-    T = real(C)
-    @test @inferred(besselj0(C(1, 1))) isa C broken = C !== ComplexF64
-    @test @inferred(besselj1(C(1, 1))) isa C broken = C !== ComplexF64
-    @test @inferred(bessely0(C(1, 1))) isa C broken = C !== ComplexF64
-    @test @inferred(bessely1(C(1, 1))) isa C broken = C !== ComplexF64
-    @test @inferred(jinc(C(1, 1))) isa C broken = C !== ComplexF64
-    @test @inferred(besselj(2, C(1, 1))) isa C broken = C !== ComplexF64
-    @test @inferred(bessely(2, C(1, 1))) isa C broken = C !== ComplexF64
-    @test @inferred(besseli(2, C(1, 1))) isa C broken = C !== ComplexF64
-    @test @inferred(besselk(2, C(1, 1))) isa C broken = C !== ComplexF64
-    @test @inferred(besseljx(2, C(1, 1))) isa C broken = C !== ComplexF64
-    @test @inferred(besselyx(2, C(1, 1))) isa C broken = C !== ComplexF64
-    @test @inferred(besselix(2, C(1, 1))) isa C broken = C !== ComplexF64
-    @test @inferred(besselkx(2, C(1, 1))) isa C broken = C !== ComplexF64
-    @test @inferred(hankelh1(2, C(1, 1))) isa C broken = C !== ComplexF64
-    @test @inferred(hankelh2(2, C(1, 1))) isa C broken = C !== ComplexF64
-    @test @inferred(hankelh1x(2, C(1, 1))) isa C broken = C !== ComplexF64
-    @test @inferred(hankelh2x(2, C(1, 1))) isa C broken = C !== ComplexF64
-    @test @inferred(sphericalbesselj(2, C(1, 1))) isa C broken = C !== ComplexF64
-    @test @inferred(sphericalbessely(2, C(1, 1))) isa C broken = C !== ComplexF64
+    @test @inferred(besselj0(C(1, 1))) isa C
+    @test @inferred(besselj1(C(1, 1))) isa C
+    @test @inferred(bessely0(C(1, 1))) isa C
+    @test @inferred(bessely1(C(1, 1))) isa C
+    @test @inferred(jinc(C(1, 1))) isa C
+    @test @inferred(besselj(2, C(1, 1))) isa C
+    @test @inferred(bessely(2, C(1, 1))) isa C
+    @test @inferred(besseli(2, C(1, 1))) isa C
+    @test @inferred(besselk(2, C(1, 1))) isa C
+    @test @inferred(besseljx(2, C(1, 1))) isa C
+    @test @inferred(besselyx(2, C(1, 1))) isa C
+    @test @inferred(besselix(2, C(1, 1))) isa C
+    @test @inferred(besselkx(2, C(1, 1))) isa C
+    @test @inferred(hankelh1(2, C(1, 1))) isa C
+    @test @inferred(hankelh2(2, C(1, 1))) isa C
+    @test @inferred(hankelh1x(2, C(1, 1))) isa C
+    @test @inferred(hankelh2x(2, C(1, 1))) isa C
+    @test @inferred(sphericalbesselj(2, C(1, 1))) isa C
+    @test @inferred(sphericalbessely(2, C(1, 1))) isa C
 end
 
 # `Integer` and `Rational` arguments promote to `Float64`


### PR DESCRIPTION
Continues the type-stability work from #549 by fixing the largest group of `broken`
entries in the sweep, 43 of them, and closes #547 on the way. The sweep goes from
280 pass / 58 broken to 325 pass / 15 broken; of the 15 that remain, 12 are the
incomplete gamma and `expint` entries that #550 addresses.

### The Bessel order forced `Float64`

`besselj(nu::Real, x::AbstractFloat)` and its seven siblings ended in

```julia
real(besselj(float(nu), complex(x)))
```

`float(nu)` maps every `Integer` and `Rational` order to `Float64`, and the complex
method then promoted the argument up to match, so the argument's precision was lost:

```julia
julia> besseli(2, Float16(1))          # before
0.1357476  # ::Float64
```

The fix is to promote the two arguments against each other in the value domain
(`promotereal`) rather than putting `nu` through `float` first, so that the order
adopts the precision of the argument. The same change to the `besselh`/`besselhx`
layer covers `hankelh1`/`hankelh2` and the scaled variants, and
`sphericalbessel[jy]` get a promoting method plus a same-precision one so that the
half-integer order `nu + one(nu)/2` no longer widens an integer `nu`.

`besselj0`/`besselj1`/`bessely0`/`bessely1` on `ComplexF32`, and `jinc` on
`ComplexF32`, are fixed by the same change: they are defined as `besselj(0, z)` etc.,
so an integer order was the whole problem there too.

### Fixes #547

That fall-through also had no method to land on for a `Float16` argument of integer
order, so `besselj(2, Float16(1))` recursed until the stack overflowed. Adding the
two missing `Cint` methods at `Float16` fixes it, and the sweep's integer-order
testset can now include `Float16`.

### Two details worth a look

- `besselh`'s method for real arguments went from `Float64` to the hardware floats,
  so that a `Float16`/`Float32` argument keeps its precision there as well. It is
  deliberately *not* extended to `BigFloat`: `besselj`/`bessely` support `BigFloat`
  for integer orders only, so a `BigFloat` method there would work for
  `besselh(1, big(1.0))` and throw a `MethodError` for `besselh(1.2, big(1.0))`. The
  `Complex{Float16}` and `Complex{Float32}` narrowing methods for `besselh` became
  redundant and are gone.
- `sphericalbesselj`'s small-argument threshold reads `sqrt(eps(zero(T)))`, which is
  `sqrt(nextfloat(0.0))`, about `2e-162` — so that branch effectively only triggers
  at `x == 0`. It looks like `eps(T)` was meant, but changing it changes results, so
  I kept the existing behaviour and left it out of this PR.

Accuracy: every newly narrow result is within half an ulp of the correctly rounded
`Float64` reference.

### Prior art

#234 aimed at the same goal in 2020 and independently arrived at the same two
`besselj`/`bessely` `Cint`/`Float16` methods. It fixed the precision by converting
the result (`convert(typeof(x), ...)`), which hides the mixed-precision arithmetic
rather than preventing it; this PR promotes the arguments instead. #234 can be closed
once this lands.

The text of this PR and the commit was written by Claude.
