### PR TITLE
Correct the scale of the continued fraction's convergence test

### DIFF
--- a/src/expint.jl
+++ b/src/expint.jl
@@ -165,8 +165,9 @@ function En_cf_nogamma(ν::Union{T,Complex{T}}, z::Union{T,Complex{T}}, n::Int=1
     Bprev::typeof(B) = z
     A::typeof(B) = 1
     Aprev::typeof(B) = 1
-    ϵ = 10*eps(real(B))
-    scale = sqrt(floatmax(typeof(real(A))))
+    ϵ = 10*eps(T)
+    # `A` and `B` are kept below this, which bounds the products in the test by `floatmax`/16
+    scale = sqrt(floatmax(T))/4
 
     # two recurrence steps / loop
     iters = 1
@@ -181,15 +182,16 @@ function En_cf_nogamma(ν::Union{T,Complex{T}}, z::Union{T,Complex{T}}, n::Int=1
         A, Aprev = A + (ν+i-1) * Aprev, A
         B, Bprev = B + (ν+i-1) * Bprev, B
 
-        i > 4 && abs(Aprev*B - A*Bprev) < ϵ*abs(B*Bprev) && break
-
         # rescale
-        if fastabs(A) > scale
+        if max(fastabs(A), fastabs(B)) > scale
             A     /= scale
             Aprev /= scale
             B     /= scale
             Bprev /= scale
         end
+
+        # relative test on the convergents Aprev/Bprev and A/B, cleared of their denominators
+        i > 4 && abs(Aprev*B - A*Bprev) < ϵ*abs(A*Bprev) && break
     end
 
     return A/B, iters

--- a/test/expint.jl
+++ b/test/expint.jl
@@ -282,3 +282,15 @@ end
     @test expint(2+3im, 1.5) ≈ 0.041610033532947484 - 0.039327583535599371im rtol = 1e-12
     @test expint(3+1im, 2.0) ≈ 0.029047898068379150 - 0.0058773000832093846im rtol = 1e-12
 end
+
+@testset "expint continued fraction" begin
+    # These points have abs2(z) > 9, so they use the continued fraction.
+    # The reference is MPFR's incomplete gamma.
+    setprecision(BigFloat, 256) do
+        @testset "ν = $ν, z = $z" for (ν, z) in ((2, 4.15), (2, 12.0), (2, 31.81),
+                                                 (2.5, 5.91), (2.5, 33.75), (2.5, 60.0),
+                                                 (3, 35.53), (5, 41.49), (10, 35.95))
+            @test expint(ν, z) ≈ Float64(expint(BigFloat(ν), BigFloat(z))) rtol = 50*eps(Float64)
+        end
+    end
+end


### PR DESCRIPTION
Stacked on #550.

`En_cf_nogamma`'s convergence test compared `abs(Aprev*B - A*Bprev)` against `10*eps(real(B))*abs(B*Bprev)`. Three things are wrong with that:

* `eps(real(B))` is `eps` of the value `z + ν`, not of the type, so the tolerance grows with `|z|` — 7.1e-15 at `|z| = 40`.
* Dividing through by `|B*Bprev|` shows the test to be `|Aprev/Bprev - A/B| < ϵ`, i.e. absolute, on a convergent of size `|e^z E_ν(z)| ≈ 1/|z|`. With the first point that gives an effective relative tolerance of about `10*eps(one(T))*|z|²`.
* `B*Bprev` is the largest of the three products (`|B| ≈ |z||A|`), so it reaches `floatmax` while the numerator's mixed `A·B` products are still finite, and `finite < Inf` then succeeds unconditionally.

The last one is #545. Running the original loop on the `Float32` seed points the `real(z) < 0` branch picks for the reported cases, every one exits on an overflowed threshold:

| seed z | iters | rescales | rel. err |
|---|---|---|---|
| −3.5 + 0.00121i | 34 | 1 | 0.874 |
| −4.0 + 0.00138i | 221 | 21 | 0.581 |
| −6.0 + 0.00207i | 196 | 18 | 0.174 |
| −8.0 + 0.00276i | 78 | 5 | 0.0554 |
| −10.0 + 0.00345i | 20 | 0 | 0.0179 |

The fix uses `eps(T)` and `abs(A*Bprev)`, moves the rescaling above the test, tests both `|A|` and `|B|`, and lowers the threshold to `sqrt(floatmax(T))/4`. Each of those is load-bearing: the bound has to hold when the test consumes the products rather than one iteration earlier (for `Float16`, `floatmax^(1/4)` is 16, so one iteration's growth can overflow them); `A` overtakes `B` by up to 112x near the cut, so checking `A` alone understates the maximum by `|z|`; and the margin covers the overshoot between checks, there being two recurrence steps per loop iteration.

## Effect

Against `Complex{BigFloat}` references at 200 bits, grid ±60 × ±30:

| ν | worst before | worst after | mean before | mean after |
|---|---|---|---|---|
| 1 | 2.01e-12 | 4.25e-15 | 7.96e-14 | 3.68e-16 |
| 2 | 1.55e-12 | 2.62e-15 | 1.14e-13 | 3.48e-16 |
| 2.5 | 1.93e-12 | 2.63e-15 | 1.21e-13 | 3.79e-16 |
| 1+i | 1.17e-12 | 4.05e-15 | 1.03e-13 | 3.39e-16 |

Both half-planes improve by comparable factors — the right half-plane never touches the `real(z) < 0` walk, so the fix stands on its own there.

Narrow types, which is what #545 reports:

| | before | after |
|---|---|---|
| #545's eight rows (`Float32`) | worst 0.851 | worst 8.79e-7 |
| `Float32` grid, ν = 2.5, 844 points | 83 above 1e-5, worst 0.864 | **0 above 1e-5**, worst 1.23e-6 |
| `Float16` grid, ν = 2, 458 points | 90 above 1e-2, worst 0.651 | **0 above 1e-2**, median 1.8 ulps |

Cost: unchanged per iteration (3.50 → 3.88 ns real, 16.7 → 17.0 ns complex, for `En_cf` at ν = 2.5); the ~15% more iterations are the ones the old test skipped.

## Tests

A new `expint continued fraction` testset covers nine points with `abs2(z) > 9`, for ν = 2, 2.5, 3, 5 and 10, against MPFR's incomplete gamma at `rtol = 50*eps(Float64)`. All nine fail on the base branch, by 74 to 1313 ulps, and pass here, within 8.

Full suite passes: `expint` 6373 pass, 1 pre-existing `@test_broken`.

## Not fixed here

#453 improves about 5x (worst 2.75e-13 at z = 31.8 → 5.54e-14 at z = 2.89) but stays open: its residual is the cancellation in the series about the origin below `|z| = 3`, which is #551's mechanism. #546 is untouched. Details and measurements in https://github.com/JuliaMath/SpecialFunctions.jl/issues/453#issuecomment-5379303050.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
